### PR TITLE
dev

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Authors@R: c(
 	person("Paul-Christian", 
 		"Bürkner", 
 		role = c("rev"), 
-		email = "paul.buerkner@gmail.com"))
+		email = "paul.buerkner@gmail.com")
 	)
 Maintainer: Dominique Makowski <dom.makowski@gmail.com>
 URL: https://github.com/easystats/bayestestR

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,11 @@ Authors@R: c(
 		"Wilson", 
 		role = c("aut"), 
 		email = "michael.d.wilson@curtin.edu.au", 
-		comment = c(ORCID = "0000-0003-4143-7308"))
+		comment = c(ORCID = "0000-0003-4143-7308")),
+	person("Paul-Christian", 
+		"Bürkner", 
+		role = c("rev"), 
+		email = "paul.buerkner@gmail.com"))
 	)
 Maintainer: Dominique Makowski <dom.makowski@gmail.com>
 URL: https://github.com/easystats/bayestestR

--- a/R/bayesfactor.R
+++ b/R/bayesfactor.R
@@ -14,7 +14,7 @@
 #' @inheritParams bayesfactor_models
 #' @inheritParams bayesfactor_inclusion
 #'
-#' @return Some type of Bayes factor, depending on the input. See \code{\link{bayesfactor_savagedickey}}, \code{\link{bayesfactor_models}} or \code{\link{bayesfactor_inclusion}}
+#' @return Some type of Bayes factor, depending on the input. See \code{\link{bayesfactor_parameters}}, \code{\link{bayesfactor_models}} or \code{\link{bayesfactor_inclusion}}
 #'
 #'
 #' @examples

--- a/R/bayesfactor_parameters.R
+++ b/R/bayesfactor_parameters.R
@@ -106,6 +106,7 @@ bayesfactor_parameters <- function(posterior, prior = NULL, direction = "two-sid
   UseMethod("bayesfactor_parameters")
 }
 
+#' @rdname bayesfactor_parameters
 #' @export
 bayesfactor_savagedickey <- function(posterior, prior = NULL, direction = "two-sided", null = 0, verbose = TRUE, ...) {
   .Deprecated("bayesfactor_parameters")

--- a/R/convert_pd_to_p.R
+++ b/R/convert_pd_to_p.R
@@ -2,18 +2,18 @@
 #'
 #' Enables a conversion between sProbability of Direction (pd) and p-value.
 #'
-#' @param pd A Probability of Direction (pd) value.
+#' @param pd A Probability of Direction (pd) value (between 0 and 1).
 #' @param p A p-value.
 #' @param direction What type of p-value is requested or provided. Can be \code{"two-sided"} (default, two tailed) or \code{"one-sided"} (one tailed).
 #' @param ... Arguments passed to or from other methods.
 #'
 #' @examples
-#' pd_to_p(pd = 95)
-#' pd_to_p(pd = 95, direction = "one-sided")
+#' pd_to_p(pd = 0.95)
+#' pd_to_p(pd = 0.95, direction = "one-sided")
 #' @export
 pd_to_p <- function(pd, direction = "two-sided", ...) {
   direction <- .get_direction(direction)
-  p <- (1 - pd / 100)
+  p <- (1 - pd)
   if (direction == 0) {
     p <- 2 * p
   }
@@ -28,7 +28,7 @@ p_to_pd <- function(p, direction = "two-sided", ...) {
   if (direction == 0) {
     p <- p / 2
   }
-  (1 - p) * 100
+  (1 - p)
 }
 
 

--- a/R/describe_posterior.R
+++ b/R/describe_posterior.R
@@ -185,7 +185,7 @@ describe_posterior <- function(posteriors, centrality = "median", dispersion = F
     # Bayes Factors
 
     if (any(c("bf", "bayesfactor", "bayes_factor") %in% test)) {
-      test_bf <- bayesfactor_savagedickey(x, prior = bf_prior, ...)
+      test_bf <- bayesfactor_parameters(x, prior = bf_prior, ...)
       if (!"Parameter" %in% names(test_bf)) {
         test_bf <- cbind(data.frame("Parameter" = "Posterior"), test_bf)
       }

--- a/R/equivalence_test.R
+++ b/R/equivalence_test.R
@@ -167,6 +167,7 @@ equivalence_test.data.frame <- function(x, range = "default", ci = .89, verbose 
     dat,
     stringsAsFactors = FALSE
   )
+  row.names(out) <- NULL
 
   attr(out, "object_name") <- deparse(substitute(x), width.cutoff = 500)
   class(out) <- unique(c("equivalence_test", "see_equivalence_test", class(out)))

--- a/R/map_estimate.R
+++ b/R/map_estimate.R
@@ -1,6 +1,6 @@
 #' Maximum A Posteriori (MAP) Estimate
 #'
-#' Find the \strong{Highest Maximum A Posteriori (MAP)} estimate of a posterior, i.e., the most probable value. It corresponds to the "peak" (or the \emph{mode}) of the posterior distribution. Note this function relies on \link{estimate_density}, which by default uses a different smoothing bandwidth (\code{"SJ"}) from the legacy default implemented the base R \link{density} function (\code{"nrd0"}).
+#' Find the \strong{Highest Maximum A Posteriori (MAP)} estimate of a posterior, i.e., the value associated with the highest probability density (the "peak" of the posterior distribution). In other words, it is an estimation of the \emph{mode} for continuous parameters. Note that this function relies on \link{estimate_density}, which by default uses a different smoothing bandwidth (\code{"SJ"}) from the legacy default implemented the base R \link{density} function (\code{"nrd0"}).
 #'
 #' @inheritParams hdi
 #' @inheritParams estimate_density

--- a/R/map_estimate.R
+++ b/R/map_estimate.R
@@ -1,6 +1,6 @@
-#' Maximum A Posteriori (MAP) Estimate
+#' Maximum A Posteriori probability estimate (MAP)
 #'
-#' Find the \strong{Highest Maximum A Posteriori (MAP)} estimate of a posterior, i.e., the value associated with the highest probability density (the "peak" of the posterior distribution). In other words, it is an estimation of the \emph{mode} for continuous parameters. Note that this function relies on \link{estimate_density}, which by default uses a different smoothing bandwidth (\code{"SJ"}) from the legacy default implemented the base R \link{density} function (\code{"nrd0"}).
+#' Find the \strong{Highest Maximum A Posteriori probability estimate (MAP)} of a posterior, i.e., the value associated with the highest probability density (the "peak" of the posterior distribution). In other words, it is an estimation of the \emph{mode} for continuous parameters. Note that this function relies on \link{estimate_density}, which by default uses a different smoothing bandwidth (\code{"SJ"}) compared to the legacy default implemented the base R \link{density} function (\code{"nrd0"}).
 #'
 #' @inheritParams hdi
 #' @inheritParams estimate_density

--- a/R/p_map.R
+++ b/R/p_map.R
@@ -1,6 +1,6 @@
-#' Bayesian p-value based on the density at the Maximum A Priori (MAP)
+#' Bayesian p-value based on the density at the Maximum A Posteriori (MAP)
 #'
-#' Compute a Bayesian equivalent of the p-value, related to the odds that a parameter (described by its posterior distribution) has against the null hypothesis (\emph{h0}) using Mills' (2014, 2017) \emph{Objective Bayesian Hypothesis Testing} framework. It is mathematically based on the density at the Maximum A Priori (MAP) and corresponds to the density value at 0 divided by the density at the MAP estimate.
+#' Compute a Bayesian equivalent of the p-value, related to the odds that a parameter (described by its posterior distribution) has against the null hypothesis (\emph{h0}) using Mills' (2014, 2017) \emph{Objective Bayesian Hypothesis Testing} framework. It corresponds to the density value at 0 divided by the density at the Maximum A Posteriori (MAP).
 #'
 #'
 #' @param precision Number of points for density estimation. See the \code{n}-parameter in \link[=density]{density}.

--- a/README.Rmd
+++ b/README.Rmd
@@ -264,7 +264,7 @@ For more info, see [the Bayes factors vignette](https://easystats.github.io/baye
 
 ### MAP-based *p*-value
 
-[**`p_map()`**](https://easystats.github.io/bayestestR/reference/p_map.html) computes a Bayesian equivalent of the p-value, related to the odds that a parameter (described by its posterior distribution) has against the null hypothesis (*h0*) using Mills' (2014, 2017) *Objective Bayesian Hypothesis Testing* framework. It is mathematically based on the density at the Maximum A Priori (MAP) and corresponds to the density value at 0 divided by the density of the MAP estimate.
+[**`p_map()`**](https://easystats.github.io/bayestestR/reference/p_map.html) computes a Bayesian equivalent of the p-value, related to the odds that a parameter (described by its posterior distribution) has against the null hypothesis (*h0*) using Mills' (2014, 2017) *Objective Bayesian Hypothesis Testing* framework. It corresponds to the density value at 0 divided by the density at the Maximum A Posteriori (MAP).
 
 ```{r message=FALSE, warning=FALSE, results='hide'}
 p_map(rnorm(1000, 1, 1))

--- a/README.Rmd
+++ b/README.Rmd
@@ -91,7 +91,7 @@ describe_posterior(rnorm(1000))
 
 ### MAP Estimate
 
-[**`map_estimate()`**](https://easystats.github.io/bayestestR/reference/map_estimate.html) find the **Highest Maximum A Posteriori (MAP)** estimate of a posterior, *i.e.,* the most probable value.
+[**`map_estimate()`**](https://easystats.github.io/bayestestR/reference/map_estimate.html) find the **Highest Maximum A Posteriori (MAP)** estimate of a posterior, *i.e.*, the value associated with the highest probability density (the "peak" of the posterior distribution). In other words, it is an estimation of the *mode* for continuous parameters.
 
 ```{r message=FALSE, warning=FALSE, results='hide'}
 map_estimate(rnorm(1000, 1, 1))

--- a/man/bayesfactor.Rd
+++ b/man/bayesfactor.Rd
@@ -35,7 +35,7 @@ or a model to be used as a denominator. Ignored for \code{BFBayesFactor}.}
 \item{prior_odds}{Optional vector of prior odds for the models. See \code{\link[BayesFactor]{priorOdds<-}}.}
 }
 \value{
-Some type of Bayes factor, depending on the input. See \code{\link{bayesfactor_savagedickey}}, \code{\link{bayesfactor_models}} or \code{\link{bayesfactor_inclusion}}
+Some type of Bayes factor, depending on the input. See \code{\link{bayesfactor_parameters}}, \code{\link{bayesfactor_models}} or \code{\link{bayesfactor_inclusion}}
 }
 \description{
 This function compte the Bayes factors (BFs) that are appropriate to the input.

--- a/man/bayesfactor_parameters.Rd
+++ b/man/bayesfactor_parameters.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/bayesfactor_parameters.R
 \name{bayesfactor_parameters}
 \alias{bayesfactor_parameters}
+\alias{bayesfactor_savagedickey}
 \alias{bayesfactor_parameters.numeric}
 \alias{bayesfactor_parameters.stanreg}
 \alias{bayesfactor_parameters.brmsfit}
@@ -10,6 +11,9 @@
 \title{Savage-Dickey density ratio Bayes Factor (BF)}
 \usage{
 bayesfactor_parameters(posterior, prior = NULL,
+  direction = "two-sided", null = 0, verbose = TRUE, ...)
+
+bayesfactor_savagedickey(posterior, prior = NULL,
   direction = "two-sided", null = 0, verbose = TRUE, ...)
 
 \method{bayesfactor_parameters}{numeric}(posterior, prior = NULL,

--- a/man/map_estimate.Rd
+++ b/man/map_estimate.Rd
@@ -5,7 +5,7 @@
 \alias{map_estimate.numeric}
 \alias{map_estimate.stanreg}
 \alias{map_estimate.brmsfit}
-\title{Maximum A Posteriori (MAP) Estimate}
+\title{Maximum A Posteriori probability estimate (MAP)}
 \usage{
 map_estimate(x, ...)
 
@@ -48,7 +48,7 @@ is a model-object, returns a data frame with following columns:
   }
 }
 \description{
-Find the \strong{Highest Maximum A Posteriori (MAP)} estimate of a posterior, i.e., the most probable value. It corresponds to the "peak" (or the \emph{mode}) of the posterior distribution. Note this function relies on \link{estimate_density}, which by default uses a different smoothing bandwidth (\code{"SJ"}) from the legacy default implemented the base R \link{density} function (\code{"nrd0"}).
+Find the \strong{Highest Maximum A Posteriori probability estimate (MAP)} of a posterior, i.e., the value associated with the highest probability density (the "peak" of the posterior distribution). In other words, it is an estimation of the \emph{mode} for continuous parameters. Note that this function relies on \link{estimate_density}, which by default uses a different smoothing bandwidth (\code{"SJ"}) compared to the legacy default implemented the base R \link{density} function (\code{"nrd0"}).
 }
 \examples{
 library(bayestestR)

--- a/man/p_map.Rd
+++ b/man/p_map.Rd
@@ -6,7 +6,7 @@
 \alias{p_map.stanreg}
 \alias{p_map.brmsfit}
 \alias{p_map.BFBayesFactor}
-\title{Bayesian p-value based on the density at the Maximum A Priori (MAP)}
+\title{Bayesian p-value based on the density at the Maximum A Posteriori (MAP)}
 \usage{
 p_map(x, ...)
 
@@ -43,7 +43,7 @@ or the zero-inflated part of the model be returned? May be abbreviated. Only
 applies to \pkg{brms}-models.}
 }
 \description{
-Compute a Bayesian equivalent of the p-value, related to the odds that a parameter (described by its posterior distribution) has against the null hypothesis (\emph{h0}) using Mills' (2014, 2017) \emph{Objective Bayesian Hypothesis Testing} framework. It is mathematically based on the density at the Maximum A Priori (MAP) and corresponds to the density value at 0 divided by the density at the MAP estimate.
+Compute a Bayesian equivalent of the p-value, related to the odds that a parameter (described by its posterior distribution) has against the null hypothesis (\emph{h0}) using Mills' (2014, 2017) \emph{Objective Bayesian Hypothesis Testing} framework. It corresponds to the density value at 0 divided by the density at the Maximum A Posteriori (MAP).
 }
 \examples{
 library(bayestestR)

--- a/man/pd_to_p.Rd
+++ b/man/pd_to_p.Rd
@@ -16,7 +16,7 @@ convert_p_to_pd(p, direction = "two-sided", ...)
 convert_pd_to_p(pd, direction = "two-sided", ...)
 }
 \arguments{
-\item{pd}{A Probability of Direction (pd) value.}
+\item{pd}{A Probability of Direction (pd) value (between 0 and 1).}
 
 \item{direction}{What type of p-value is requested or provided. Can be \code{"two-sided"} (default, two tailed) or \code{"one-sided"} (one tailed).}
 
@@ -28,6 +28,6 @@ convert_pd_to_p(pd, direction = "two-sided", ...)
 Enables a conversion between sProbability of Direction (pd) and p-value.
 }
 \examples{
-pd_to_p(pd = 95)
-pd_to_p(pd = 95, direction = "one-sided")
+pd_to_p(pd = 0.95)
+pd_to_p(pd = 0.95, direction = "one-sided")
 }

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -19,60 +19,74 @@
 
 
 @book{mcelreath2018statistical,
-  title={Statistical rethinking: A Bayesian course with examples in R and Stan},
-  author={McElreath, Richard},
-  year={2018},
-  publisher={Chapman and Hall/CRC}
+	doi = {10.1201/9781315372495},
+	url = {https://doi.org/10.1201%2F9781315372495},
+	year = 2018,
+	month = {jan},
+	publisher = {Chapman and Hall/{CRC}},
+	author = {Richard McElreath},
+	title = {Statistical Rethinking}
 }
-
 
 @article{wagenmakers2018bayesian,
-  title={Bayesian inference for psychology. Part I: Theoretical advantages and practical ramifications},
-  author={Wagenmakers, Eric-Jan and Marsman, Maarten and Jamil, Tahira and Ly, Alexander and Verhagen, Josine and Love, Jonathon and Selker, Ravi and Gronau, Quentin F and {\v{S}}m{\'\i}ra, Martin and Epskamp, Sacha and others},
-  journal={Psychonomic bulletin \& review},
-  volume={25},
-  number={1},
-  pages={35--57},
-  year={2018},
-  publisher={Springer}
+	doi = {10.3758/s13423-017-1343-3},
+	url = {https://doi.org/10.3758%2Fs13423-017-1343-3},
+	year = 2017,
+	month = {aug},
+	publisher = {Springer Nature},
+	volume = {25},
+	number = {1},
+	pages = {35--57},
+	author = {Eric-Jan Wagenmakers and Maarten Marsman and Tahira Jamil and Alexander Ly and Josine Verhagen and Jonathon Love and Ravi Selker and Quentin F. Gronau and Martin {\v{S}}m{\'{\i}}ra and Sacha Epskamp and Dora Matzke and Jeffrey N. Rouder and Richard D. Morey},
+	title = {Bayesian inference for psychology. Part I: Theoretical advantages and practical ramifications},
+	journal = {Psychonomic Bulletin {\&} Review}
 }
+
 
 @article{kruschke2018rejecting,
-  title={Rejecting or accepting parameter values in Bayesian estimation},
-  author={Kruschke, John K},
-  journal={Advances in Methods and Practices in Psychological Science},
-  volume={1},
-  number={2},
-  pages={270--280},
-  year={2018},
-  publisher={SAGE Publications Sage CA: Los Angeles, CA}
+	doi = {10.1177/2515245918771304},
+	url = {https://doi.org/10.1177%2F2515245918771304},
+	year = 2018,
+	month = {may},
+	publisher = {{SAGE} Publications},
+	volume = {1},
+	number = {2},
+	pages = {270--280},
+	author = {John K. Kruschke},
+	title = {Rejecting or Accepting Parameter Values in Bayesian Estimation},
+	journal = {Advances in Methods and Practices in Psychological Science}
 }
-
 
 
 
 @article{benjamin2018redefine,
-  title={Redefine statistical significance},
-  author={Benjamin, Daniel J and Berger, James O and Johannesson, Magnus and Nosek, Brian A and Wagenmakers, E-J and Berk, Richard and Bollen, Kenneth A and Brembs, Bj{\"o}rn and Brown, Lawrence and Camerer, Colin and others},
-  journal={Nature Human Behaviour},
-  volume={2},
-  number={1},
-  pages={6},
-  year={2018},
-  publisher={Nature Publishing Group}
+	doi = {10.1038/s41562-017-0189-z},
+	url = {https://doi.org/10.1038%2Fs41562-017-0189-z},
+	year = 2017,
+	month = {sep},
+	publisher = {Springer Nature},
+	volume = {2},
+	number = {1},
+	pages = {6--10},
+	author = {Daniel J. Benjamin and James O. Berger and Magnus Johannesson and Brian A. Nosek and E.-J. Wagenmakers and Richard Berk and Kenneth A. Bollen and Björn Brembs and Lawrence Brown and Colin Camerer and David Cesarini and Christopher D. Chambers and Merlise Clyde and Thomas D. Cook and Paul De Boeck and Zoltan Dienes and Anna Dreber and Kenny Easwaran and Charles Efferson and Ernst Fehr and Fiona Fidler and Andy P. Field and Malcolm Forster and Edward I. George and Richard Gonzalez and Steven Goodman and Edwin Green and Donald P. Green and Anthony G. Greenwald and Jarrod D. Hadfield and Larry V. Hedges and Leonhard Held and Teck Hua Ho and Herbert Hoijtink and Daniel J. Hruschka and Kosuke Imai and Guido Imbens and John P. A. Ioannidis and Minjeong Jeon and James Holland Jones and Michael Kirchler and David Laibson and John List and Roderick Little and Arthur Lupia and Edouard Machery and Scott E. Maxwell and Michael McCarthy and Don A. Moore and Stephen L. Morgan and Marcus Munaf{\'{o}} and Shinichi Nakagawa and Brendan Nyhan and Timothy H. Parker and Luis Pericchi and Marco Perugini and Jeff Rouder and Judith Rousseau and Victoria Savalei and Felix D. Schönbrodt and Thomas Sellke and Betsy Sinclair and Dustin Tingley and Trisha Van Zandt and Simine Vazire and Duncan J. Watts and Christopher Winship and Robert L. Wolpert and Yu Xie and Cristobal Young and Jonathan Zinman and Valen E. Johnson},
+	title = {Redefine statistical significance},
+	journal = {Nature Human Behaviour}
 }
 
 
 
 @article{dienes2018four,
-  title={Four reasons to prefer Bayesian analyses over significance testing},
-  author={Dienes, Zoltan and Mclatchie, Neil},
-  journal={Psychonomic bulletin \& review},
-  volume={25},
-  number={1},
-  pages={207--218},
-  year={2018},
-  publisher={Springer}
+	doi = {10.3758/s13423-017-1266-z},
+	url = {https://doi.org/10.3758%2Fs13423-017-1266-z},
+	year = 2017,
+	month = {mar},
+	publisher = {Springer Nature},
+	volume = {25},
+	number = {1},
+	pages = {207--218},
+	author = {Zoltan Dienes and Neil Mclatchie},
+	title = {Four reasons to prefer Bayesian analyses over significance testing},
+	journal = {Psychonomic Bulletin {\&} Review}
 }
 
 
@@ -142,169 +156,216 @@
 
 
 @article{wagenmakers2017need,
-  title={The need for Bayesian hypothesis testing in psychological science},
-  author={Wagenmakers, Eric-Jan and Verhagen, Josine and Ly, Alexander and Matzke, Dora and Steingroever, Helen and Rouder, Jeffrey N and Morey, Richard D},
-  journal={Psychological science under scrutiny: Recent challenges and proposed solutions},
-  pages={123--138},
-  year={2017},
-  publisher={Wiley New York, NY}
+	doi = {10.1002/9781119095910.ch8},
+	url = {https://doi.org/10.1002%2F9781119095910.ch8},
+	year = 2017,
+	month = {feb},
+	publisher = {John Wiley {\&} Sons, Inc.},
+	pages = {123--138},
+	author = {Eric-Jan Wagenmakers and Josine Verhagen and Alexander Ly and Dora Matzke and Helen Steingroever and Jeffrey N. Rouder and Richard D. Morey},
+	title = {The Need for Bayesian Hypothesis Testing in Psychological Science},
+	booktitle = {Psychological Science Under Scrutiny}
 }
 
 
 @article{gronau2017bayesian,
-  title={A Bayesian model-averaged meta-analysis of the power pose effect with informed and default priors: The case of felt power},
-  author={Gronau, Quentin F and Van Erp, Sara and Heck, Daniel W and Cesario, Joseph and Jonas, Kai J and Wagenmakers, Eric-Jan},
-  journal={Comprehensive Results in Social Psychology},
-  volume={2},
-  number={1},
-  pages={123--138},
-  year={2017},
-  publisher={Taylor \& Francis}
+	doi = {10.1080/23743603.2017.1326760},
+	url = {https://doi.org/10.1080%2F23743603.2017.1326760},
+	year = 2017,
+	month = {jan},
+	publisher = {Informa {UK} Limited},
+	volume = {2},
+	number = {1},
+	pages = {123--138},
+	author = {Quentin F. Gronau and Sara Van Erp and Daniel W. Heck and Joseph Cesario and Kai J. Jonas and Eric-Jan Wagenmakers},
+	title = {A Bayesian model-averaged meta-analysis of the power pose effect with informed and default priors: the case of felt power},
+	journal = {Comprehensive Results in Social Psychology}
 }
 
 @article{gronau2017simple,
-  title={A simple method for comparing complex models: Bayesian model comparison for hierarchical multinomial processing tree models using warp-III bridge sampling},
-  author={Gronau, Quentin F and Wagenmakers, Eric-Jan and Heck, Daniel W and Matzke, Dora},
-  journal={Psychometrika},
-  pages={1--24},
-  year={2017},
-  publisher={Springer}
+	doi = {10.1007/s11336-018-9648-3},
+	url = {https://doi.org/10.1007%2Fs11336-018-9648-3},
+	year = 2018,
+	month = {nov},
+	publisher = {Springer Nature},
+	volume = {84},
+	number = {1},
+	pages = {261--284},
+	author = {Quentin F. Gronau and Eric-Jan Wagenmakers and Daniel W. Heck and Dora Matzke},
+	title = {A Simple Method for Comparing Complex Models: Bayesian Model Comparison for Hierarchical Multinomial Processing Tree Models Using Warp-{III} Bridge Sampling},
+	journal = {Psychometrika}
 }
 
 @article{piironen2017comparison,
-  title={Comparison of Bayesian predictive methods for model selection},
-  author={Piironen, Juho and Vehtari, Aki},
-  journal={Statistics and Computing},
-  volume={27},
-  number={3},
-  pages={711--735},
-  year={2017},
-  publisher={Springer}
+	doi = {10.1007/s11222-016-9649-y},
+	url = {https://doi.org/10.1007%2Fs11222-016-9649-y},
+	year = 2016,
+	month = {apr},
+	publisher = {Springer Nature},
+	volume = {27},
+	number = {3},
+	pages = {711--735},
+	author = {Juho Piironen and Aki Vehtari},
+	title = {Comparison of Bayesian predictive methods for model selection},
+	journal = {Statistics and Computing}
 }
 
 @article{burkner2017brms,
-  title={brms: An R package for Bayesian multilevel models using Stan},
-  author={B{\"u}rkner, Paul-Christian and others},
-  journal={Journal of Statistical Software},
-  volume={80},
-  number={1},
-  pages={1--28},
-  year={2017},
-  publisher={Foundation for Open Access Statistics}
+	doi = {10.18637/jss.v080.i01},
+	url = {https://doi.org/10.18637%2Fjss.v080.i01},
+	year = 2017,
+	publisher = {Foundation for Open Access Statistic},
+	volume = {80},
+	number = {1},
+	author = {Paul-Christian Bürkner},
+	title = {brms: An R Package for Bayesian Multilevel Models Using Stan},
+	journal = {Journal of Statistical Software}
 }
 
 
 @article{szucs2016empirical,
-  title={Empirical assessment of published effect sizes and power in the recent cognitive neuroscience and psychology literature},
-  author={Szucs, Denes and Ioannidis, John PA},
-  journal={BioRxiv},
-  pages={071530},
-  year={2016},
-  publisher={Cold Spring Harbor Laboratory}
+	doi = {10.1371/journal.pbio.2000797},
+	url = {https://doi.org/10.1371%2Fjournal.pbio.2000797},
+	year = 2017,
+	month = {mar},
+	publisher = {Public Library of Science ({PLoS})},
+	volume = {15},
+	number = {3},
+	pages = {e2000797},
+	author = {Denes Szucs and John P. A. Ioannidis},
+	editor = {Eric-Jan Wagenmakers},
+	title = {Empirical assessment of published effect sizes and power in the recent cognitive neuroscience and psychology literature},
+	journal = {{PLOS} Biology}
 }
 
 
 @article{wagenmakers2016bayesian,
-  title={Bayesian benefits for the pragmatic researcher},
-  author={Wagenmakers, Eric-Jan and Morey, Richard D and Lee, Michael D},
-  journal={Current Directions in Psychological Science},
-  volume={25},
-  number={3},
-  pages={169--176},
-  year={2016},
-  publisher={Sage Publications Sage CA: Los Angeles, CA}
+	doi = {10.1177/0963721416643289},
+	url = {https://doi.org/10.1177%2F0963721416643289},
+	year = 2016,
+	month = {jun},
+	publisher = {{SAGE} Publications},
+	volume = {25},
+	number = {3},
+	pages = {169--176},
+	author = {Eric-Jan Wagenmakers and Richard D. Morey and Michael D. Lee},
+	title = {Bayesian Benefits for the Pragmatic Researcher},
+	journal = {Current Directions in Psychological Science}
 }
 
 
 @article{ly2016harold,
-  title={Harold Jeffreys’s default Bayes factor hypothesis tests: Explanation, extension, and application in psychology},
-  author={Ly, Alexander and Verhagen, Josine and Wagenmakers, Eric-Jan},
-  journal={Journal of Mathematical Psychology},
-  volume={72},
-  pages={19--32},
-  year={2016},
-  publisher={Elsevier}
+	doi = {10.1016/j.jmp.2015.06.004},
+	url = {https://doi.org/10.1016%2Fj.jmp.2015.06.004},
+	year = 2016,
+	month = {jun},
+	publisher = {Elsevier {BV}},
+	volume = {72},
+	pages = {19--32},
+	author = {Alexander Ly and Josine Verhagen and Eric-Jan Wagenmakers},
+	title = {Harold Jeffreys's default Bayes factor hypothesis tests: Explanation, extension, and application in psychology},
+	journal = {Journal of Mathematical Psychology}
 }
 
 @article{wasserstein2016asa,
-  title={The ASA’s statement on p-values: context, process, and purpose},
-  author={Wasserstein, Ronald L and Lazar, Nicole A and others},
-  journal={The American Statistician},
-  volume={70},
-  number={2},
-  pages={129--133},
-  year={2016}
+	doi = {10.1080/00031305.2016.1154108},
+	url = {https://doi.org/10.1080%2F00031305.2016.1154108},
+	year = 2016,
+	month = {apr},
+	publisher = {Informa {UK} Limited},
+	volume = {70},
+	number = {2},
+	pages = {129--133},
+	author = {Ronald L. Wasserstein and Nicole A. Lazar},
+	title = {The {ASA} Statement on p-Values: Context, Process, and Purpose},
+	journal = {The American Statistician}
 }
 
 
 @article{etz2016bayesian,
-  title={A Bayesian perspective on the reproducibility project: Psychology},
-  author={Etz, Alexander and Vandekerckhove, Joachim},
-  journal={PloS one},
-  volume={11},
-  number={2},
-  pages={e0149794},
-  year={2016},
-  publisher={Public Library of Science}
+	doi = {10.1371/journal.pone.0149794},
+	url = {https://doi.org/10.1371%2Fjournal.pone.0149794},
+	year = 2016,
+	month = {feb},
+	publisher = {Public Library of Science ({PLoS})},
+	volume = {11},
+	number = {2},
+	pages = {e0149794},
+	author = {Alexander Etz and Joachim Vandekerckhove},
+	editor = {Daniele Marinazzo},
+	title = {A Bayesian Perspective on the Reproducibility Project: Psychology},
+	journal = {{PLOS} {ONE}}
 }
 
 
 @article{burrell2016machine,
-  title={How the machine ‘thinks’: Understanding opacity in machine learning algorithms},
-  author={Burrell, Jenna},
-  journal={Big Data \& Society},
-  volume={3},
-  number={1},
-  pages={2053951715622512},
-  year={2016},
-  publisher={SAGE Publications Sage UK: London, England}
+	doi = {10.1177/2053951715622512},
+	url = {https://doi.org/10.1177%2F2053951715622512},
+	year = 2016,
+	month = {jan},
+	publisher = {{SAGE} Publications},
+	volume = {3},
+	number = {1},
+	pages = {205395171562251},
+	author = {Jenna Burrell},
+	title = {How the machine `thinks': Understanding opacity in machine learning algorithms},
+	journal = {Big Data {\&} Society}
 }
 
 @article{castelvecchi2016can,
-  title={Can we open the black box of AI?},
-  author={Castelvecchi, Davide},
-  journal={Nature News},
-  volume={538},
-  number={7623},
-  pages={20},
-  year={2016}
+	doi = {10.1038/538020a},
+	url = {https://doi.org/10.1038%2F538020a},
+	year = 2016,
+	month = {oct},
+	publisher = {Springer Science and Business Media {LLC}},
+	volume = {538},
+	number = {7623},
+	pages = {20--23},
+	author = {Davide Castelvecchi},
+	title = {Can we open the black box of {AI}?},
+	journal = {Nature}
 }
 
 
 @incollection{cohen2016earth,
-  title={The earth is round (p<. 05)},
-  author={Cohen, Jacob},
-  booktitle={What if there were no significance tests?},
-  pages={69--82},
-  year={2016},
-  publisher={Routledge}
+	doi = {10.1037/0003-066x.49.12.997},
+	url = {https://doi.org/10.1037%2F0003-066x.49.12.997},
+	year = 1994,
+	publisher = {American Psychological Association ({APA})},
+	volume = {49},
+	number = {12},
+	pages = {997--1003},
+	author = {Jacob Cohen},
+	title = {The earth is round (p{\hspace{0.6em}}$\less${\hspace{0.6em}}.05).},
+	journal = {American Psychologist}
 }
 
 
 
 @article{maxwell2015psychology,
-  title={Is psychology suffering from a replication crisis? What does “failure to replicate” really mean?},
-  author={Maxwell, Scott E and Lau, Michael Y and Howard, George S},
-  journal={American Psychologist},
-  volume={70},
-  number={6},
-  pages={487},
-  year={2015},
-  publisher={American Psychological Association}
+	doi = {10.1037/a0039400},
+	url = {https://doi.org/10.1037%2Fa0039400},
+	year = 2015,
+	publisher = {American Psychological Association ({APA})},
+	volume = {70},
+	number = {6},
+	pages = {487--498},
+	author = {Scott E. Maxwell and Michael Y. Lau and George S. Howard},
+	title = {Is psychology suffering from a replication crisis? What does {\textquotedblleft}failure to replicate{\textquotedblright} really mean?},
+	journal = {American Psychologist}
 }
 
 
 
 @book{kruschke2015doing,
-	address = {Amsterdam},
-	edition = {2. ed},
-	title = {Doing {Bayesian} data analysis: a tutorial with {R}, {JAGS}, and {Stan}},
-	isbn = {978-0-12-405888-0},
-	shorttitle = {Doing {Bayesian} data analysis},
-	language = {eng},
-	publisher = {Academic Press},
-	author = {Kruschke, John K},
-	year = {2015}
+	doi = {10.1016/b978-0-12-405888-0.00014-3},
+	url = {https://doi.org/10.1016%2Fb978-0-12-405888-0.00014-3},
+	year = 2015,
+	publisher = {Elsevier},
+	pages = {399--416},
+	author = {John K. Kruschke},
+	title = {Stan},
+	booktitle = {Doing Bayesian Data Analysis}
 }
 
 
@@ -318,21 +379,16 @@
 
 
 @article{morey2014simple,
-  title={Simple relation between Bayesian order-restricted and point-null hypothesis tests},
-  author={Morey, Richard D and Wagenmakers, Eric-Jan},
-  journal={Statistics \& Probability Letters},
-  volume={92},
-  pages={121--124},
-  year={2014},
-  publisher={Elsevier}
-}
-
-
-
-@misc{mcelreath2014rethinking,
-  title={rethinking: Statistical Rethinking book package. R package version 1.391},
-  author={McElreath, R},
-  year={2014}
+	doi = {10.1016/j.spl.2014.05.010},
+	url = {https://doi.org/10.1016%2Fj.spl.2014.05.010},
+	year = 2014,
+	month = {sep},
+	publisher = {Elsevier {BV}},
+	volume = {92},
+	pages = {121--124},
+	author = {Richard D. Morey and Eric-Jan Wagenmakers},
+	title = {Simple relation between Bayesian order-restricted and point-null hypothesis tests},
+	journal = {Statistics {\&} Probability Letters}
 }
 
 
@@ -340,37 +396,43 @@
 
 
 @article{chambers2014instead,
-  title={Instead of 'playing the game' it is time to change the rules: Registered Reports at AIMS Neuroscience and beyond},
-  author={Chambers, Christopher D and Feredoes, Eva and Muthukumaraswamy, Suresh Daniel and Etchells, Peter},
-  journal={AIMS Neuroscience},
-  volume={1},
-  number={1},
-  pages={4--17},
-  year={2014},
-  publisher={Aims Press}
+	doi = {10.3934/neuroscience.2014.1.4},
+	url = {https://doi.org/10.3934%2Fneuroscience.2014.1.4},
+	year = 2014,
+	publisher = {American Institute of Mathematical Sciences ({AIMS})},
+	volume = {1},
+	number = {1},
+	pages = {4--17},
+	author = {Christopher D. Chambers and   and Eva Feredoes and Suresh D. Muthukumaraswamy and Peter J. Etchells},
+	title = {Instead of {\textquotedblleft}playing the game{\textquotedblright} it is time to change the rules: Registered Reports at $\less$em$\greater${AIMS} Neuroscience$\less$/em$\greater$ and beyond},
+	journal = {{AIMS} Neuroscience}
 }
 
 
 @article{dienes2014using,
-  title={Using Bayes to get the most out of non-significant results},
-  author={Dienes, Zoltan},
-  journal={Frontiers in psychology},
-  volume={5},
-  pages={781},
-  year={2014},
-  publisher={Frontiers}
+	doi = {10.3389/fpsyg.2014.00781},
+	url = {https://doi.org/10.3389%2Ffpsyg.2014.00781},
+	year = 2014,
+	month = {jul},
+	publisher = {Frontiers Media {SA}},
+	volume = {5},
+	author = {Zoltan Dienes},
+	title = {Using Bayes to get the most out of non-significant results},
+	journal = {Frontiers in Psychology}
 }
 
 
 @article{jarosz2014odds,
-  title={What are the odds? A practical guide to computing and reporting Bayes factors},
-  author={Jarosz, Andrew F and Wiley, Jennifer},
-  journal={The Journal of Problem Solving},
-  volume={7},
-  number={1},
-  pages={2},
-  year={2014},
-  publisher={Purdue University Press}
+	doi = {10.7771/1932-6246.1167},
+	url = {https://doi.org/10.7771%2F1932-6246.1167},
+	year = 2014,
+	month = {nov},
+	publisher = {Purdue University (bepress)},
+	volume = {7},
+	number = {1},
+	author = {Andrew F. Jarosz and Jennifer Wiley},
+	title = {What Are the Odds? A Practical Guide to Computing and Reporting Bayes Factors},
+	journal = {The Journal of Problem Solving}
 }
 
 
@@ -378,12 +440,15 @@
 
 
 @incollection{mills2014bayesian,
-  title={Bayesian MCMC estimation},
-  author={Mills, Jeffrey A and Parent, Olivier},
-  booktitle={Handbook of Regional Science},
-  pages={1571--1595},
-  year={2014},
-  publisher={Springer}
+	doi = {10.1007/978-3-642-23430-9_89},
+	url = {https://doi.org/10.1007%2F978-3-642-23430-9_89},
+	year = 2013,
+	month = {jul},
+	publisher = {Springer Berlin Heidelberg},
+	pages = {1571--1595},
+	author = {Jeffrey A. Mills and Olivier Parent},
+	title = {Bayesian {MCMC} Estimation},
+	booktitle = {Handbook of Regional Science}
 }
 
 
@@ -398,27 +463,33 @@
 
 
 @article{andrews2013prior,
-  title={Prior approval: The growth of Bayesian methods in psychology},
-  author={Andrews, Mark and Baguley, Thom},
-  journal={British Journal of Mathematical and Statistical Psychology},
-  volume={66},
-  number={1},
-  pages={1--7},
-  year={2013},
-  publisher={Wiley Online Library}
+	doi = {10.1111/bmsp.12004},
+	url = {https://doi.org/10.1111%2Fbmsp.12004},
+	year = 2013,
+	month = {jan},
+	publisher = {Wiley},
+	volume = {66},
+	number = {1},
+	pages = {1--7},
+	author = {Mark Andrews and Thom Baguley},
+	title = {Prior approval: The growth of Bayesian methods in psychology},
+	journal = {British Journal of Mathematical and Statistical Psychology}
 }
 
 
 
 @article{kruschke2012time,
-  title={The time has come: Bayesian methods for data analysis in the organizational sciences},
-  author={Kruschke, John K and Aguinis, Herman and Joo, Harry},
-  journal={Organizational Research Methods},
-  volume={15},
-  number={4},
-  pages={722--752},
-  year={2012},
-  publisher={Sage Publications Sage CA: Los Angeles, CA}
+	doi = {10.1177/1094428112457829},
+	url = {https://doi.org/10.1177%2F1094428112457829},
+	year = 2012,
+	month = {sep},
+	publisher = {{SAGE} Publications},
+	volume = {15},
+	number = {4},
+	pages = {722--752},
+	author = {John K. Kruschke and Herman Aguinis and Harry Joo},
+	title = {The Time Has Come: Bayesian methods for data analysis in the organizational sciences},
+	journal = {Organizational Research Methods}
 }
 
 
@@ -449,39 +520,48 @@
 
 
 @article{wagenmakers2010bayesian,
-  title={Bayesian hypothesis testing for psychologists: A tutorial on the Savage--Dickey method},
-  author={Wagenmakers, Eric-Jan and Lodewyckx, Tom and Kuriyal, Himanshu and Grasman, Raoul},
-  journal={Cognitive psychology},
-  volume={60},
-  number={3},
-  pages={158--189},
-  year={2010},
-  publisher={Elsevier}
+	doi = {10.1016/j.cogpsych.2009.12.001},
+	url = {https://doi.org/10.1016%2Fj.cogpsych.2009.12.001},
+	year = 2010,
+	month = {may},
+	publisher = {Elsevier {BV}},
+	volume = {60},
+	number = {3},
+	pages = {158--189},
+	author = {Eric-Jan Wagenmakers and Tom Lodewyckx and Himanshu Kuriyal and Raoul Grasman},
+	title = {Bayesian hypothesis testing for psychologists: A tutorial on the Savage{\textendash}Dickey method},
+	journal = {Cognitive Psychology}
 }
 
 
 @article{kruschke2010believe,
-  title={What to believe: Bayesian methods for data analysis},
-  author={Kruschke, John K},
-  journal={Trends in cognitive sciences},
-  volume={14},
-  number={7},
-  pages={293--300},
-  year={2010},
-  publisher={Elsevier}
+	doi = {10.1016/j.tics.2010.05.001},
+	url = {https://doi.org/10.1016%2Fj.tics.2010.05.001},
+	year = 2010,
+	month = {jul},
+	publisher = {Elsevier {BV}},
+	volume = {14},
+	number = {7},
+	pages = {293--300},
+	author = {John K. Kruschke},
+	title = {What to believe: Bayesian methods for data analysis},
+	journal = {Trends in Cognitive Sciences}
 }
 
 
 
 @article{wagenmakers2007practical,
-  title={A practical solution to the pervasive problems ofp values},
-  author={Wagenmakers, Eric-Jan},
-  journal={Psychonomic bulletin \& review},
-  volume={14},
-  number={5},
-  pages={779--804},
-  year={2007},
-  publisher={Springer}
+	doi = {10.3758/bf03194105},
+	url = {https://doi.org/10.3758%2Fbf03194105},
+	year = 2007,
+	month = {oct},
+	publisher = {Springer Science and Business Media {LLC}},
+	volume = {14},
+	number = {5},
+	pages = {779--804},
+	author = {Eric-Jan Wagenmakers},
+	title = {A practical solution to the pervasive problems ofp values},
+	journal = {Psychonomic Bulletin {\&} Review}
 }
 
 
@@ -496,32 +576,28 @@
 
 
 @article{kirk1996practical,
-  title={Practical significance: A concept whose time has come},
-  author={Kirk, Roger E},
-  journal={Educational and psychological measurement},
-  volume={56},
-  number={5},
-  pages={746--759},
-  year={1996},
-  publisher={Sage Publications Sage CA: Thousand Oaks, CA}
+	doi = {10.1177/0013164496056005002},
+	url = {https://doi.org/10.1177%2F0013164496056005002},
+	year = 1996,
+	month = {oct},
+	publisher = {{SAGE} Publications},
+	volume = {56},
+	number = {5},
+	pages = {746--759},
+	author = {Roger E. Kirk},
+	title = {Practical Significance: A Concept Whose Time Has Come},
+	journal = {Educational and Psychological Measurement}
 }
 
-@article{wagenmakers2010bayesian,
-  title={Bayesian hypothesis testing for psychologists: A tutorial on the Savage--Dickey method},
-  author={Wagenmakers, Eric-Jan and Lodewyckx, Tom and Kuriyal, Himanshu and Grasman, Raoul},
-  journal={Cognitive psychology},
-  volume={60},
-  number={3},
-  pages={158--189},
-  year={2010},
-  publisher={Elsevier}
-}
+
 
 
 @article{cohen1988statistical,
-  title={Statistical power analysis for the social sciences},
-  author={Cohen, Jacob},
-  year={1988},
-  publisher={Hillsdale, NJ: Erlbaum}
+	doi = {10.4324/9780203771587},
+	url = {https://doi.org/10.4324%2F9780203771587},
+	year = 2013,
+	month = {may},
+	publisher = {Routledge},
+	author = {Jacob Cohen},
+	title = {Statistical Power Analysis for the Behavioral Sciences}
 }
-

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -147,7 +147,7 @@ p_direction(distribution_normal(100, 0.4, 0.2))
 
 ### Bayes Factor
 
-[`bayesfactor_savagedickey()`](https://easystats.github.io/bayestestR/reference/bayesfactor_savagedickey.html) computes the ratio between the density of a single value (typically the
+[`bayesfactor_parameters()`](https://easystats.github.io/bayestestR/reference/bayesfactor_parameters.html) computes the ratio between the density of a single value (typically the
 null) in two distributions. When these distributions are the prior and the posterior
 distributions, this ratio can be used to examine the degree by which the mass of
 the posterior distribution has shifted further away from or closer to the null value
@@ -158,7 +158,7 @@ less or more likely given the observed data (see figure 3, panel C). The Savage-
 prior <- distribution_normal(1000, mean = 0, sd = 1)
 posterior <- distribution_normal(1000, mean = 1, sd = 0.7)
 
-bayesfactor_savagedickey(posterior, prior, direction = "two-sided", hypothesis = 0)
+bayesfactor_parameters(posterior, prior, direction = "two-sided", hypothesis = 0)
 #> # Bayes Factor (Savage-Dickey density ratio)
 #> 
 #>  Bayes Factor

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -49,7 +49,7 @@ The following demonstration of functions is accompanied by figures to illustrate
 
 **bayestestR** offers two functions to compute point-estimates from posterior distributions: `map_estimate()` and `point_estimate()`, the latter providing options to calculate the mean, median or MAP estimate of a posterior distribution. [`map_estimate()`](https://easystats.github.io/bayestestR/reference/map_estimate.html) is a convenient function to calculate the **Maximum A Posteriori** (MAP) estimate directly.
 
-The **posterior mean** minimizes expected _squared_ error, whereas the **posterior median** minimizes expected _absolute_ error (i.e. the difference of estimates from true values over samples). The **MAP estimate** is the most probable value of a posterior distribution.
+The **posterior mean** minimizes expected _squared_ error, whereas the **posterior median** minimizes expected _absolute_ error (i.e. the difference of estimates from true values over samples). The **MAP estimate** corresponds to the most probable value of a posterior distribution.
 
 ``` r
 set.seed(1)
@@ -169,7 +169,7 @@ bayesfactor_parameters(posterior, prior, direction = "two-sided", hypothesis = 0
 
 ### MAP-based *p*-value
 
-[`p_map()`](https://easystats.github.io/bayestestR/reference/p_map.html) computes the odds that a parameter (described by its posterior distribution) has against the null hypothesis (*h0*) using Mills’ *Objective Bayesian Hypothesis Testing* framework [@mills2018objective; @mills2014bayesian]. It is mathematically based on the density at the Maximum A Priori (MAP) and corresponds to the density value at 0 divided by the density at the MAP estimate (see figure 3, panel D).
+[`p_map()`](https://easystats.github.io/bayestestR/reference/p_map.html) computes the odds that a parameter (described by its posterior distribution) has against the null hypothesis (*h0*) using Mills’ *Objective Bayesian Hypothesis Testing* framework [@mills2018objective; @mills2014bayesian]. It corresponds to the density value at 0 divided by the density at the MAP - the Maximum A Posteriori (see figure 3, panel D).
 
 ``` r
 p_map(distribution_normal(1000, mean = 1))


### PR DESCRIPTION
This PR will attempt at addressing the reviewer's [comments](https://github.com/openjournals/joss-reviews/issues/1541):

Reviewer 1 (@paul-buerkner)
- [x] **All the citations in the software paper should list a DOI (if they have one) as per reviewer checklist above.**

- Added DOIs for all refs but the following (none was found):
  - `see` package ([here](https://github.com/easystats/see/issues/36))
  - rstanarm package
  - BayesFactor package
  - Mill's "Objective Bayesian Precise Hypothesis Testing" (@tszanalytics do you have a DOI for that?)
  - Multiple Comparisons with BayesFactor, Part 2 (Morey's blog, 2015)
  - Practical bayesian optimization of machine learning algorithms (Snoek's proceedings, 2012)
  - Jeffrey's Theory of Probability book

- [x] **The definition of the maximum a-posteriori value as "the most probable value" is not entirely correct for continuous parameters. Instead it is the value with the highest density (which still have probability zero for continuous parameters).**

- We changed its definition to the following:

"find the **Highest Maximum A Posteriori (MAP)** estimate of a posterior, *i.e.*, the value associated with the highest probability density (the "peak" of the posterior distribution). In other words, it is an estimation of the *mode* for continuous parameters."

- [x] **you seem to use the abbreviation MAP both for the maximum a posteriori and the maximum a-priori value. This will likely confuse readers.**

- This was likely an error and was addressed by replacing instances of the latter by the former (the maximum a posteriori).