### PR TITLE
Fixed bug in effective_sample

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,11 @@ Authors@R: c(
 		"Gronau",
 		role = c("ctb"),
 		comment = c(ORCID = "0000-0001-5510-6943"))
+	person("Sam", 
+	  "Crawley",
+	  role = c("ctb"),
+	  email = "sam@crawley.nz",
+	  comment = c(ORCID = "0000-0002-7847-0411"))
 	)
 Maintainer: Dominique Makowski <dom.makowski@gmail.com>
 URL: https://easystats.github.io/bayestestR/

--- a/R/effective_sample.R
+++ b/R/effective_sample.R
@@ -47,7 +47,7 @@ effective_sample.brmsfit <- function(model, effects = c("fixed", "random", "all"
   }
 
   s <- rstan::summary(model$fit)$summary
-  s <- s[make.names(rownames(s)) %in% colnames(pars), ]
+  s <- subset(s, subset = make.names(rownames(s)) %in% colnames(pars))
 
   data.frame(
     Parameter = make.names(rownames(s)),

--- a/tests/testthat/test-effective_sample.R
+++ b/tests/testthat/test-effective_sample.R
@@ -1,0 +1,38 @@
+if (require("rstanarm") && require("brms") && require("insight")) {
+  test_that("effective_sample", {
+    brms_1 <- insight::download_model("brms_1")
+    res <- effective_sample(brms_1)
+    testthat::expect_equal(
+      res,
+      data.frame(
+        Parameter = c("b_Intercept", "b_wt", "b_cyl"),
+        ESS = c(5242, 2071, 1951),
+        stringsAsFactors = F
+      )
+    )
+
+    brms_null_1 <- insight::download_model("brms_null_1")
+    res <- effective_sample(brms_null_1)
+    testthat::expect_equal(
+      res,
+      data.frame(
+        Parameter = c("b_Intercept"),
+        ESS = c(2888),
+        stringsAsFactors = F
+      )
+    )
+
+    brms_null_2 <- insight::download_model("brms_null_2")
+    res <- effective_sample(brms_null_2)
+    testthat::expect_equal(
+      res,
+      data.frame(
+        Parameter = c("b_Intercept"),
+        ESS = c(1059),
+        stringsAsFactors = F
+      )
+    )
+
+  })
+
+}


### PR DESCRIPTION
Previously, if a model had only one parameter (e.g. a null model) effective_sample threw an error. This was because the subset was returning a vector rather than a matrix.
