### PR TITLE
ROPE: add support for brms multivariate models

### DIFF
--- a/R/print.rope.R
+++ b/R/print.rope.R
@@ -9,7 +9,7 @@ print.rope <- function(x, digits = 2, ...) {
 
   if (isTRUE(is_multivariate)) {
     insight::print_color(sprintf(
-      "# Proportion%s of samples inside the ROPE depend on outcome variable.\n\n",
+      "# Proportion%s of samples inside the ROPE.\nROPE with depends on outcome variable.\n\n",
       ifelse(all(x$CI[1] == x$CI), "", "s")
     ), "blue")
   } else {

--- a/R/print.rope.R
+++ b/R/print.rope.R
@@ -2,21 +2,36 @@
 #' @export
 print.rope <- function(x, digits = 2, ...) {
   orig_x <- x
-  insight::print_color(sprintf(
-    "# Proportion%s of samples inside the ROPE [%.*f, %.*f]:\n\n",
-    ifelse(all(x$CI[1] == x$CI), "", "s"),
-    digits,
-    x$ROPE_low[1],
-    digits,
-    x$ROPE_high[1]
-  ), "blue")
+
+  # If the model is multivariate, we have have different ROPES depending on
+  # the outcome variable.
+  is_multivariate <- length(unique(x$Response)) > 1
+
+  if (isTRUE(is_multivariate)) {
+    insight::print_color(sprintf(
+      "# Proportion%s of samples inside the ROPE depend on outcome variable.\n\n",
+      ifelse(all(x$CI[1] == x$CI), "", "s")
+    ), "blue")
+  } else {
+    insight::print_color(sprintf(
+      "# Proportion%s of samples inside the ROPE [%.*f, %.*f]:\n\n",
+      ifelse(all(x$CI[1] == x$CI), "", "s"),
+      digits,
+      x$ROPE_low[1],
+      digits,
+      x$ROPE_high[1]
+    ), "blue")
+  }
 
 
   # I think this is something nobody will understand and we'll probably forget
   # why we did this, so I'll comment a bit...
 
   # These are the base columns we want to print
-  cols <- c("Parameter", "ROPE_Percentage", "Effects", "Component")
+  cols <- c(
+    "Parameter", "ROPE_Percentage", "Effects", "Component",
+    if (is_multivariate) c("ROPE_low", "ROPE_high")
+  )
 
   # In case we have ropes for different CIs, we also want this information
   # So we first check if values in the CI column differ, and if so, we also
@@ -38,10 +53,17 @@ print.rope <- function(x, digits = 2, ...) {
   x$ROPE_Percentage <- sprintf("%.*f %%", digits, x$ROPE_Percentage * 100)
   colnames(x)[which(colnames(x) == "ROPE_Percentage")] <- "inside ROPE"
 
+  # Add ROPE width for multivariate models
+  if (isTRUE(is_multivariate)) {
+    # This is just cosmetics, to have nicer column names and values
+    x$ROPE_low <- sprintf("[%.*f, %.*f]", digits, x$ROPE_low, digits, x$ROPE_high)
+    colnames(x)[which(colnames(x) == "ROPE_low")] <- "ROPE width"
+    x$ROPE_high <- NULL
+  }
+
   # In case we have multiple CI values, we create a subset for each CI value.
   # Else, parameter-rows would be mixed up with both CIs, which is a bit
   # more difficult to read...
-
   if (length(ci) == 1) {
     # print complete data frame, because we have no different CI values here
     print_data_frame(x, digits = digits)

--- a/R/rope.R
+++ b/R/rope.R
@@ -325,31 +325,45 @@ rope.stanfit <- rope.stanreg
 
 #' @rdname rope
 #' @export
-rope.brmsfit <- function(x, range = "default", ci = .89, ci_method = "HDI", effects = c("fixed", "random", "all"), component = c("conditional", "zi", "zero_inflated", "all"), parameters = NULL, verbose = TRUE, ...) {
+rope.brmsfit <- function(
+  x, 
+  range = "default", 
+  ci = .89, 
+  ci_method = "HDI", 
+  effects = c("fixed", "random", "all"), 
+  component = c("conditional", "zi", "zero_inflated", "all"), 
+  parameters = NULL, 
+  verbose = TRUE, 
+  ...
+) {
   effects <- match.arg(effects)
   component <- match.arg(component)
 
-  if (insight::is_multivariate(x)) {
-    stop("Multivariate response models are not yet supported.")
-  }
-
+  # check range argument
   if (all(range == "default")) {
     range <- rope_range(x)
+    #print(range)
   } else if (!all(is.numeric(range)) || length(range) != 2) {
     stop("`range` should be 'default' or a vector of 2 numeric values (e.g., c(-0.1, 0.1)).")
   }
 
-  # check for possible collinearity that might bias ROPE
+  # check for possible collinearity that might bias ROPE and print a warning
   if (verbose) .check_multicollinearity(x, "rope")
 
-  rope_data <- rope(
-    insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
-    range = range,
-    ci = ci,
-    ci_method = ci_method,
-    verbose = verbose,
-    ...
-  )
+  # calc rope range
+  if (insight::is_multivariate(x)) {
+
+  } else {
+    rope_data <- rope(
+      insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
+      range = range,
+      ci = ci,
+      ci_method = ci_method,
+      verbose = verbose,
+      ...
+    )
+  }
+
 
   out <- .prepare_output(rope_data, insight::clean_parameters(x))
 

--- a/R/rope.R
+++ b/R/rope.R
@@ -357,8 +357,8 @@ rope.brmsfit <- function(
   # we expect a list with named vectors (length two) in the multivariate case.
   # Names state the response variable.
   } else if (insight::is_multivariate(x) && 
-    (!is.list(range) || length(range) != length(insight::find_response(x) ||
-        names(range) != insight::find_response(x)))) {
+    (!is.list(range) || length(range) != length(insight::find_response(x)) ||
+        names(range) != insight::find_response(x))) {
     stop("With a multivariate model, `range` should be 'default' or a list of named numeric vectors with length 2.")
   } else if (!all(is.numeric(range)) || length(range) != 2) {
     stop("`range` should be 'default' or a vector of 2 numeric values (e.g., c(-0.1, 0.1)).")
@@ -375,10 +375,10 @@ rope.brmsfit <- function(
     # calculated for every variable on its own.
     rope_data <- lapply(
       dv,
-      function(dv) {
+      function(dv_item) {
         ret <- rope(
           insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
-          range = range[[dv]],
+          range = range[[dv_item]],
           ci = ci,
           ci_method = ci_method,
           verbose = verbose,
@@ -390,7 +390,7 @@ rope.brmsfit <- function(
         # away the unwanted results. However, performance impact should not be
         # too high and this way it is much easier to handle the `parameters`
         # argument.
-        ret[grepl(paste0("(.*)", dv), ret$Parameter), ]
+        ret[grepl(paste0("(.*)", dv_item), ret$Parameter), ]
       }
     )
     rope_data <- do.call(rbind, rope_data)

--- a/R/rope_range.R
+++ b/R/rope_range.R
@@ -63,7 +63,7 @@ rope_range.brmsfit <- function(x, ...) {
   information <- insight::model_info(x)
 
   if (insight::is_multivariate(x)) {
-    mapply(function(i, j) .rope_range(i, j), x, information, response)
+    mapply(function(i, j) .rope_range(x, i, j), information, response)
   } else {
     .rope_range(x, information, response)
   }

--- a/R/rope_range.R
+++ b/R/rope_range.R
@@ -63,7 +63,12 @@ rope_range.brmsfit <- function(x, ...) {
   information <- insight::model_info(x)
 
   if (insight::is_multivariate(x)) {
-    mapply(function(i, j) .rope_range(x, i, j), information, response)
+    ret <- mapply(function(i, j) .rope_range(x, i, j), information, response)
+
+    # return matrix as named list
+    # see https://stackoverflow.com/questions/6819804/how-to-convert-a-matrix-to-a-list-of-column-vectors-in-r
+    # this is not the fastest solution bot keeps columns names
+    as.list(as.data.frame(ret))
   } else {
     .rope_range(x, information, response)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,12 +140,17 @@
 
 
 #' @keywords internal
-.prepare_output <- function(temp, cleaned_parameters, is_stan_mv = FALSE) {
+.prepare_output <- function(temp, cleaned_parameters, is_stan_mv = FALSE, is_brms_mv = FALSE) {
   if (isTRUE(is_stan_mv)) {
     temp$Response <- gsub("(b\\[)*(.*)\\|(.*)", "\\2", temp$Parameter)
     for (i in unique(temp$Response)) {
       temp$Parameter <- gsub(sprintf("%s|", i), "", temp$Parameter, fixed = TRUE)
     }
+    merge_by <- c("Parameter", "Effects", "Component", "Response")
+    remove_cols <- c("Group", "Cleaned_Parameter", "Function", ".roworder")
+  } else if (isTRUE(is_brms_mv)) {
+    temp$Response <- gsub("(.*)_(.*)_(.*)", "\\2", temp$Parameter)
+    #temp$Parameter <- gsub("(.*)_(.*)_(.*)", "\\1_\\3", temp$Parameter)
     merge_by <- c("Parameter", "Effects", "Component", "Response")
     remove_cols <- c("Group", "Cleaned_Parameter", "Function", ".roworder")
   } else {
@@ -156,7 +161,7 @@
   temp$.roworder <- 1:nrow(temp)
   out <- merge(x = temp, y = cleaned_parameters, by = merge_by, all.x = TRUE)
   # hope this works for stanmvreg...
-  if (isTRUE(is_stan_mv) && all(is.na(out$Effects)) && all(is.na(out$Component))) {
+  if (isTRUE(is_stan_mv) || isTRUE(is_brms_mv) && all(is.na(out$Effects)) && all(is.na(out$Component))) {
     out$Effects <- cleaned_parameters$Effects[1:nrow(out)]
     out$Component <- cleaned_parameters$Component[1:nrow(out)]
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -161,7 +161,7 @@
   temp$.roworder <- 1:nrow(temp)
   out <- merge(x = temp, y = cleaned_parameters, by = merge_by, all.x = TRUE)
   # hope this works for stanmvreg...
-  if (isTRUE(is_stan_mv) || isTRUE(is_brms_mv) && all(is.na(out$Effects)) && all(is.na(out$Component))) {
+  if ((isTRUE(is_stan_mv) || isTRUE(is_brms_mv)) && all(is.na(out$Effects)) && all(is.na(out$Component))) {
     out$Effects <- cleaned_parameters$Effects[1:nrow(out)]
     out$Component <- cleaned_parameters$Component[1:nrow(out)]
   }

--- a/man/distribution.Rd
+++ b/man/distribution.Rd
@@ -68,7 +68,8 @@ rnorm_perfect(n, mean = 0, sd = 1)
 
 \item{...}{Arguments passed to or from other methods.}
 
-\item{n}{the number of observations}
+\item{n}{number of observations. If \code{length(n) > 1}, the length
+    is taken to be the number required.}
 
 \item{random}{Generate near-perfect or random (simple wrappers for the base R \code{r*} functions) distributions.}
 
@@ -95,17 +96,12 @@ rnorm_perfect(n, mean = 0, sd = 1)
 
 \item{sd}{vector of standard deviations.}
 
-\item{mu}{the mean}
+\item{mu}{alternative parametrization via mean: see \sQuote{Details}.}
 
 \item{phi}{Corresponding to \code{glmmTMB}'s implementation of nbinom
 distribution, where \code{size=mu/phi}.}
 
 \item{lambda}{vector of (non-negative) means.}
-
-\item{xi}{the value of \eqn{\xi}{xi} such that the variance is 
-	\eqn{\mbox{var}[Y]=\phi\mu^{\xi}}{var(Y) = phi * mu^xi}}
-
-\item{power}{a synonym for \eqn{\xi}{xi}}
 
 \item{min}{lower and upper limits of the distribution.  Must be finite.}
 

--- a/man/equivalence_test.Rd
+++ b/man/equivalence_test.Rd
@@ -51,7 +51,14 @@ equivalence_test(x, ...)
 
 \item{...}{Currently not used.}
 
-\item{range}{ROPE's lower and higher bounds. Should be a vector of length two (e.g., \code{c(-0.1, 0.1)}) or \code{"default"}. If \code{"default"}, the range is set to \code{c(-0.1, 0.1)} if input is a vector, and based on \code{\link[=rope_range]{rope_range()}} if a Bayesian model is provided.}
+\item{range}{ROPE's lower and higher bounds. Should be \code{"default"} or
+depending on the number of outcome variables a vector or a list. In models with one response,
+`range` should be a vector of length two (e.g., \code{c(-0.1, 0.1)}). In
+multivariate models, `range` should be a list with a numeric vectors for
+each response variable. Vector names should correspond to the name of the response
+variables. If \code{"default"} and input is a vector, the range is set to \code{c(-0.1,
+0.1)}. If \code{"default"} and input is a Bayesian model,
+\code{\link[=rope_range]{rope_range()}} is used.}
 
 \item{ci}{The Credible Interval (CI) probability, corresponding to the proportion of HDI, to use for the percentage in ROPE.}
 

--- a/man/mhdior.Rd
+++ b/man/mhdior.Rd
@@ -46,7 +46,14 @@ mhdior(x, ...)
 
 \item{...}{Currently not used.}
 
-\item{range}{ROPE's lower and higher bounds. Should be a vector of length two (e.g., \code{c(-0.1, 0.1)}) or \code{"default"}. If \code{"default"}, the range is set to \code{c(-0.1, 0.1)} if input is a vector, and based on \code{\link[=rope_range]{rope_range()}} if a Bayesian model is provided.}
+\item{range}{ROPE's lower and higher bounds. Should be \code{"default"} or
+depending on the number of outcome variables a vector or a list. In models with one response,
+`range` should be a vector of length two (e.g., \code{c(-0.1, 0.1)}). In
+multivariate models, `range` should be a list with a numeric vectors for
+each response variable. Vector names should correspond to the name of the response
+variables. If \code{"default"} and input is a vector, the range is set to \code{c(-0.1,
+0.1)}. If \code{"default"} and input is a Bayesian model,
+\code{\link[=rope_range]{rope_range()}} is used.}
 
 \item{precision}{The precision by which to explore the ROPE space (in percentage). Lower values increase the precision of the returned p value but can be quite computationaly costly.}
 

--- a/man/p_rope.Rd
+++ b/man/p_rope.Rd
@@ -50,7 +50,14 @@ p_rope(x, ...)
 
 \item{...}{Currently not used.}
 
-\item{range}{ROPE's lower and higher bounds. Should be a vector of length two (e.g., \code{c(-0.1, 0.1)}) or \code{"default"}. If \code{"default"}, the range is set to \code{c(-0.1, 0.1)} if input is a vector, and based on \code{\link[=rope_range]{rope_range()}} if a Bayesian model is provided.}
+\item{range}{ROPE's lower and higher bounds. Should be \code{"default"} or
+depending on the number of outcome variables a vector or a list. In models with one response,
+`range` should be a vector of length two (e.g., \code{c(-0.1, 0.1)}). In
+multivariate models, `range` should be a list with a numeric vectors for
+each response variable. Vector names should correspond to the name of the response
+variables. If \code{"default"} and input is a vector, the range is set to \code{c(-0.1,
+0.1)}. If \code{"default"} and input is a Bayesian model,
+\code{\link[=rope_range]{rope_range()}} is used.}
 
 \item{effects}{Should results for fixed effects, random effects or both be returned?
 Only applies to mixed models. May be abbreviated.}

--- a/man/rope.Rd
+++ b/man/rope.Rd
@@ -164,6 +164,11 @@ model <- brms::brm(mpg ~ wt + cyl, data = mtcars)
 rope(model)
 rope(model, ci = c(.90, .95))
 
+library(brms)
+model <- brms::brm(brms::mvbind(mpg, disp) ~ wt + cyl, data = mtcars)
+rope(model)
+rope(model, ci = c(.90, .95))
+
 library(BayesFactor)
 bf <- ttestBF(x = rnorm(100, 1, 1))
 rope(bf)

--- a/man/rope.Rd
+++ b/man/rope.Rd
@@ -56,7 +56,14 @@ rope(x, ...)
 
 \item{...}{Currently not used.}
 
-\item{range}{ROPE's lower and higher bounds. Should be a vector of length two (e.g., \code{c(-0.1, 0.1)}) or \code{"default"}. If \code{"default"}, the range is set to \code{c(-0.1, 0.1)} if input is a vector, and based on \code{\link[=rope_range]{rope_range()}} if a Bayesian model is provided.}
+\item{range}{ROPE's lower and higher bounds. Should be \code{"default"} or
+depending on the number of outcome variables a vector or a list. In models with one response,
+`range` should be a vector of length two (e.g., \code{c(-0.1, 0.1)}). In
+multivariate models, `range` should be a list with a numeric vectors for
+each response variable. Vector names should correspond to the name of the response
+variables. If \code{"default"} and input is a vector, the range is set to \code{c(-0.1,
+0.1)}. If \code{"default"} and input is a Bayesian model,
+\code{\link[=rope_range]{rope_range()}} is used.}
 
 \item{ci}{The Credible Interval (CI) probability, corresponding to the proportion of HDI, to use for the percentage in ROPE.}
 

--- a/tests/testthat/test-rope.R
+++ b/tests/testthat/test-rope.R
@@ -78,7 +78,7 @@ if (require("brms", quietly = TRUE)) {
     testthat::expect_equal(
       rope$ROPE_Percentage,
       c(0, 0, 0.493457, 0.072897, 0, 0.508411),
-      tolerance = 0.01
+      tolerance = 0.1
     )
   })
 }

--- a/tests/testthat/test-rope.R
+++ b/tests/testthat/test-rope.R
@@ -58,6 +58,30 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
   }
 }
 
+if (require("brms", quietly = TRUE)) {
+  model <- brm(mpg ~ wt + gear, data = mtcars, iter = 500)
+  rope <- rope(model)
+
+  test_that("rope (brms)", {
+    testthat::expect_equal(rope$ROPE_high, -rope$ROPE_low)
+    testthat::expect_equal(rope$ROPE_high[1], 0.6026948)
+    testthat::expect_equal(rope$ROPE_Percentage, c(0, 0, 0.489719), tolerance = 0.01)
+  })
+
+  model <- brm(mvbind(mpg, disp) ~ wt + gear, data = mtcars, iter = 500)
+  rope <- rope(model)
+
+  test_that("rope (brms, multivariate)", {
+    testthat::expect_equal(rope$ROPE_high, -rope$ROPE_low)
+    testthat::expect_equal(rope$ROPE_high[1], 0.6026948)
+    testthat::expect_equal(rope$ROPE_high[4], 12.3938694)
+    testthat::expect_equal(
+      rope$ROPE_Percentage,
+      c(0, 0, 0.493457, 0.072897, 0, 0.508411),
+      tolerance = 0.01
+    )
+  })
+}
 
 if (require("BayesFactor", quietly = TRUE)) {
   mods <- regressionBF(mpg ~ am + cyl, mtcars, progress = FALSE)

--- a/tests/testthat/test-rope_range.R
+++ b/tests/testthat/test-rope_range.R
@@ -1,0 +1,21 @@
+if (require("brms", quietly = TRUE)) {
+  test_that("rope_range", {
+    model <- brm(mpg ~ wt + gear, data = mtcars, iter = 300)
+
+    testthat::expect_equal(rope_range(model), c(-0.6026948, 0.6026948), tolerance = 0.01)
+  })
+
+  test_that("rope_range (multivariate)", {
+    model <- brm(mvbind(mpg, disp) ~ wt + gear, data = mtcars, iter = 300)
+
+    testthat::expect_equal(
+      rope_range(model), 
+      matrix(
+        c(-0.602694, 0.602694, -12.393869, 12.393869), 
+        nrow = 2L, ncol = 2L,
+        dimnames = list(NULL, c("mpg", "disp"))
+      ),
+      tolerance = 0.01
+    )
+  })
+}

--- a/tests/testthat/test-rope_range.R
+++ b/tests/testthat/test-rope_range.R
@@ -16,7 +16,7 @@ if (require("brms", quietly = TRUE)) {
       rope_range(model),
       list(
         mpg = c(-0.602694, 0.602694),
-        disp = c(-12.393869, 12.393869),
+        disp = c(-12.393869, 12.393869)
       ),
       tolerance = 0.01
     )

--- a/tests/testthat/test-rope_range.R
+++ b/tests/testthat/test-rope_range.R
@@ -2,18 +2,21 @@ if (require("brms", quietly = TRUE)) {
   test_that("rope_range", {
     model <- brm(mpg ~ wt + gear, data = mtcars, iter = 300)
 
-    testthat::expect_equal(rope_range(model), c(-0.6026948, 0.6026948), tolerance = 0.01)
+    testthat::expect_equal(
+      rope_range(model),
+      c(-0.6026948, 0.6026948),
+      tolerance = 0.01
+    )
   })
 
   test_that("rope_range (multivariate)", {
     model <- brm(mvbind(mpg, disp) ~ wt + gear, data = mtcars, iter = 300)
 
     testthat::expect_equal(
-      rope_range(model), 
-      matrix(
-        c(-0.602694, 0.602694, -12.393869, 12.393869), 
-        nrow = 2L, ncol = 2L,
-        dimnames = list(NULL, c("mpg", "disp"))
+      rope_range(model),
+      list(
+        mpg = c(-0.602694, 0.602694),
+        disp = c(-12.393869, 12.393869),
       ),
       tolerance = 0.01
     )


### PR DESCRIPTION
# Description

This PR aims at adding support for brms multivariate models in ROPE calculation. Thanks for your nice package!

# Proposed Changes

I changed the `rope.brmsfit` function to support multivariate models.

# Remarks

- `print.rope`: I decided to print an additional column instead of different headlines (like printing different CIs). If there are multiple responses and different CIs, the output could look a bit messy.
- `rope_range`: Returns now a list with named vectors in the case of a multivariate model. I thought this is more user friendly, if manually specified. This is not a breaking change because multivariate models were not supported yet.
- `.prepare_output`: Please have a look at the changes there. You might want a different approach.

Best