### PR TITLE
additional attributes for BF objects

### DIFF
--- a/R/describe_posterior.R
+++ b/R/describe_posterior.R
@@ -692,6 +692,9 @@ describe_posterior.BFBayesFactor <- function(posteriors, centrality = "median", 
     out <- .merge_and_sort(out, priors_data, by = intersect(names(out), names(priors_data)), all = TRUE)
   }
 
+  attr(out, "ci_method") <- ci_method
+  attr(out, "centrality") <- centrality
+
   out
 }
 


### PR DESCRIPTION
@strengejacke Do you think this would contribute to solving https://github.com/easystats/parameters/issues/408?

# Before

``` r
library(BayesFactor)
library(bayestestR)

mod <- correlationBF(y = iris$Sepal.Length, x = iris$Sepal.Width)

str(describe_posterior(mod))
#> 'data.frame':    1 obs. of  14 variables:
#>  $ Parameter         : chr "rho"
#>  $ Median            : num -0.113
#>  $ CI                : num 0.89
#>  $ CI_low            : num -0.244
#>  $ CI_high           : num 0.0034
#>  $ pd                : num 0.93
#>  $ ROPE_CI           : num 89
#>  $ ROPE_low          : num -0.1
#>  $ ROPE_high         : num 0.1
#>  $ ROPE_Percentage   : num 0.411
#>  $ BF                : num 0.509
#>  $ Prior_Distribution: chr "cauchy"
#>  $ Prior_Location    : num 0
#>  $ Prior_Scale       : num 0.333
```

# After

```r
library(BayesFactor)
library(bayestestR)

mod <- correlationBF(y = iris$Sepal.Length, x = iris$Sepal.Width)

str(describe_posterior(mod))
#> 'data.frame':    1 obs. of  14 variables:
#>  $ Parameter         : chr "rho"
#>  $ Median            : num -0.115
#>  $ CI                : num 0.89
#>  $ CI_low            : num -0.229
#>  $ CI_high           : num 0.0229
#>  $ pd                : num 0.92
#>  $ ROPE_CI           : num 89
#>  $ ROPE_low          : num -0.1
#>  $ ROPE_high         : num 0.1
#>  $ ROPE_Percentage   : num 0.43
#>  $ BF                : num 0.509
#>  $ Prior_Distribution: chr "cauchy"
#>  $ Prior_Location    : num 0
#>  $ Prior_Scale       : num 0.333
#>  - attr(*, "ci_method")= chr "hdi"
#>  - attr(*, "centrality")= chr "median"
```