### PR TITLE
switch to testthat 3rd edition and adapt tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,99 +1,112 @@
-Package: bayestestR
 Type: Package
-Title: Understand and Describe Bayesian Models and Posterior Distributions
+Package: bayestestR
+Title: Understand and Describe Bayesian Models and Posterior
+    Distributions
 Version: 0.8.2.1
-Authors@R: c(
-    person("Dominique", 
-		"Makowski", 
-		email = "dom.makowski@gmail.com",
-		role = c("aut", "cre"), 
-		comment = c(ORCID = "0000-0001-5375-9967")),
-	person("Daniel", 
-		"Lüdecke", 
-		role = c("aut"), 
-		email = "d.luedecke@uke.de", 
-		comment = c(ORCID = "0000-0002-8895-3206")),
-	person("Mattan S.", 
-		"Ben-Shachar", 
-		role = c("aut"), 
-		email = "matanshm@post.bgu.ac.il", 
-		comment = c(ORCID = "0000-0002-4287-4801")),
-	person("Michael D.", 
-		"Wilson", 
-		role = c("aut"), 
-		email = "michael.d.wilson@curtin.edu.au", 
-		comment = c(ORCID = "0000-0003-4143-7308")),
-	person("Paul-Christian", 
-		"Bürkner", 
-		role = c("rev"), 
-		email = "paul.buerkner@gmail.com"),
-	person("Tristan", 
-		"Mahr", 
-		role = c("rev"),
-		email = "tristan.mahr@wisc.edu",
-		comment = c(ORCID = "0000-0002-8890-5116")),
-	person("Henrik",
-		"Singmann",
-		role = c("ctb"),
-		email = "singmann@gmail.com",
-		comment = c(ORCID = "0000-0002-4842-3657")),
-	person("Quentin F.",
-		"Gronau",
-		role = c("ctb"),
-		comment = c(ORCID = "0000-0001-5510-6943")),
-	person("Sam", 
-	  "Crawley",
-	  role = c("ctb"),
-	  email = "sam@crawley.nz",
-	  comment = c(ORCID = "0000-0002-7847-0411"))
-	)
+Authors@R: 
+    c(person(given = "Dominique",
+             family = "Makowski",
+             role = c("aut", "cre"),
+             email = "dom.makowski@gmail.com",
+             comment = c(ORCID = "0000-0001-5375-9967")),
+      person(given = "Daniel",
+             family = "Lüdecke",
+             role = "aut",
+             email = "d.luedecke@uke.de",
+             comment = c(ORCID = "0000-0002-8895-3206")),
+      person(given = "Mattan S.",
+             family = "Ben-Shachar",
+             role = "aut",
+             email = "matanshm@post.bgu.ac.il",
+             comment = c(ORCID = "0000-0002-4287-4801")),
+      person(given = "Michael D.",
+             family = "Wilson",
+             role = "aut",
+             email = "michael.d.wilson@curtin.edu.au",
+             comment = c(ORCID = "0000-0003-4143-7308")),
+      person(given = "Indrajeet",
+             family = "Patil",
+             role = "ctb",
+             email = "patilindrajeet.science@gmail.com",
+             comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),
+      person(given = "Paul-Christian",
+             family = "Bürkner",
+             role = "rev",
+             email = "paul.buerkner@gmail.com"),
+      person(given = "Tristan",
+             family = "Mahr",
+             role = "rev",
+             email = "tristan.mahr@wisc.edu",
+             comment = c(ORCID = "0000-0002-8890-5116")),
+      person(given = "Henrik",
+             family = "Singmann",
+             role = "ctb",
+             email = "singmann@gmail.com",
+             comment = c(ORCID = "0000-0002-4842-3657")),
+      person(given = "Quentin F.",
+             family = "Gronau",
+             role = "ctb",
+             comment = c(ORCID = "0000-0001-5510-6943")),
+      person(given = "Sam",
+             family = "Crawley",
+             role = "ctb",
+             email = "sam@crawley.nz",
+             comment = c(ORCID = "0000-0002-7847-0411")))
 Maintainer: Dominique Makowski <dom.makowski@gmail.com>
+Description: Provides utilities to describe posterior
+    distributions and Bayesian models. It includes point-estimates such as
+    Maximum A Posteriori (MAP), measures of dispersion (Highest Density
+    Interval - HDI; Kruschke, 2015 <doi:10.1016/C2012-0-00477-2>) and
+    indices used for null-hypothesis testing (such as ROPE percentage, pd
+    and Bayes factors).
+License: GPL-3
 URL: https://easystats.github.io/bayestestR/
 BugReports: https://github.com/easystats/bayestestR/issues
-Description: Provides utilities to describe posterior distributions and Bayesian models. It includes point-estimates such as Maximum A Posteriori (MAP), measures of dispersion (Highest Density Interval - HDI; Kruschke, 2015 <doi:10.1016/C2012-0-00477-2>) and indices used for null-hypothesis testing (such as ROPE percentage, pd and Bayes factors).
-License: GPL-3
-Encoding: UTF-8
-LazyData: true
 Depends:
-  R (>= 3.4)
+    R (>= 3.4)
 Imports:
-	insight (>= 0.12.0),
-	methods,
-	stats,
-	utils
+    insight (>= 0.12.0),
+    methods,
+    stats,
+    utils
 Suggests:
-	BayesFactor,
-	bayesQR,
-	bridgesampling,
-	brms,
-	broom,
-	covr,
-	dplyr,
-	effectsize,
-	emmeans,
-	GGally,
-	ggplot2,
-	ggridges,
-	httr,
-	KernSmooth,
-	knitr,
-	MASS,
-	mclust,
-	modelbased,
-	lavaan,
-	lme4,
-	logspline,
-	mediation,
-	parameters,
-	performance,
-	rmarkdown,
-	rstan,
-	rstanarm,
-	see,
-	stringr,
-	testthat,
-	tidyr,
-	tweedie
-RoxygenNote: 7.1.1
+    BayesFactor,
+    bayesQR,
+    bridgesampling,
+    brms,
+    broom,
+    covr,
+    dplyr,
+    effectsize,
+    emmeans,
+    GGally,
+    ggplot2,
+    ggridges,
+    httr,
+    KernSmooth,
+    knitr,
+    lavaan,
+    lme4,
+    logspline,
+    MASS,
+    mclust,
+    mediation,
+    modelbased,
+    parameters,
+    performance,
+    rmarkdown,
+    rstan,
+    rstanarm,
+    see,
+    stringr,
+    testthat,
+    tidyr,
+    tweedie
+VignetteBuilder: 
+    knitr
+Encoding: UTF-8
 Language: en-GB
-VignetteBuilder: knitr
+LazyData: true
+RoxygenNote: 7.1.1
+Config/testthat/edition: 3
+Config/testthat/parallel: true

--- a/R/area_under_curve.R
+++ b/R/area_under_curve.R
@@ -35,8 +35,7 @@ area_under_curve <- function(x, y, method = c("trapezoid", "step", "spline"), ..
   x <- x[idx]
   y <- y[idx]
 
-  switch(
-    match.arg(arg = method, choices = c("trapezoid", "step", "spline")),
+  switch(match.arg(arg = method, choices = c("trapezoid", "step", "spline")),
     "trapezoid" = sum((rowMeans(cbind(y[-length(y)], y[-1]))) * (x[-1] - x[-length(x)])),
     "step" = sum(y[-length(y)] * (x[-1] - x[-length(x)])),
     "spline" = stats::integrate(stats::splinefun(x, y, method = "natural"), lower = min(x), upper = max(x))$value

--- a/R/bayesfactor_models.R
+++ b/R/bayesfactor_models.R
@@ -63,7 +63,6 @@
 #'
 #' update(BFM, reference = "bottom")
 #' as.matrix(BFM)
-#'
 #' \dontrun{
 #' # With lmerMod objects:
 #' # ---------------------
@@ -155,7 +154,7 @@ bayesfactor_models.default <- function(..., denominator = 1, verbose = TRUE) {
   mnames <- sapply(match.call(expand.dots = FALSE)$`...`, .safe_deparse)
 
   # In the case of a list as direct input
-  if(length(mods) == 1 && inherits(mods[[1]], "list")){
+  if (length(mods) == 1 && inherits(mods[[1]], "list")) {
     mods <- mods[[1]]
     mnames <- names(mods)
   }
@@ -209,9 +208,10 @@ bayesfactor_models.default <- function(..., denominator = 1, verbose = TRUE) {
 
 
   .bf_models_output(res,
-                    denominator = denominator,
-                    bf_method = "BIC approximation",
-                    unsupported_models = !all(supported_models))
+    denominator = denominator,
+    bf_method = "BIC approximation",
+    unsupported_models = !all(supported_models)
+  )
 }
 
 
@@ -225,7 +225,7 @@ bayesfactor_models.default <- function(..., denominator = 1, verbose = TRUE) {
   mods <- list(...)
 
   # In the case of a list as direct input
-  if(length(mods) == 1 && inherits(mods[[1]], "list")){
+  if (length(mods) == 1 && inherits(mods[[1]], "list")) {
     mods <- mods[[1]]
     was_list <- TRUE
   } else {
@@ -297,8 +297,9 @@ bayesfactor_models.default <- function(..., denominator = 1, verbose = TRUE) {
 
 
   .bf_models_output(res,
-                    denominator = denominator,
-                    bf_method = "marginal likelihoods (bridgesampling)")
+    denominator = denominator,
+    bf_method = "marginal likelihoods (bridgesampling)"
+  )
 }
 
 
@@ -346,9 +347,10 @@ bayesfactor_models.BFBayesFactor <- function(..., verbose = TRUE) {
   )
 
   .bf_models_output(res,
-                    denominator = 1,
-                    bf_method = "JZS (BayesFactor)",
-                    unsupported_models = !"BFlinearModel" %in% class(models@denominator))
+    denominator = 1,
+    bf_method = "JZS (BayesFactor)",
+    unsupported_models = !"BFlinearModel" %in% class(models@denominator)
+  )
 }
 
 

--- a/R/bayesfactor_parameters.R
+++ b/R/bayesfactor_parameters.R
@@ -114,7 +114,6 @@
 #'   posterior <- distribution_normal(1000, mean = .5, sd = .3)
 #'   bayesfactor_parameters(posterior, prior)
 #' }
-#'
 #' \dontrun{
 #' # rstanarm models
 #' # ---------------

--- a/R/distribution.R
+++ b/R/distribution.R
@@ -21,8 +21,7 @@ distribution <- function(type = "normal", ...) {
     "gamma", "geom", "hyper", "lnorm", "multinom", "nbinom", "normal", "gaussian",
     "pois", "poisson", "student", "t", "student_t", "unif", "uniform", "weibull"
   )
-  switch(
-    match.arg(arg = type, choices = basr_r_distributions),
+  switch(match.arg(arg = type, choices = basr_r_distributions),
     "beta" = distribution_beta(...),
     "binom" = ,
     "binomial" = distribution_binomial(...),

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -151,7 +151,7 @@ point_estimate.mcmc.list <- point_estimate.bcplm
 
 
 #' @export
-point_estimate.bamlss <- function(x, centrality = "all", dispersion = FALSE,  component = c("conditional", "location", "all"), ...) {
+point_estimate.bamlss <- function(x, centrality = "all", dispersion = FALSE, component = c("conditional", "location", "all"), ...) {
   component <- match.arg(component)
   point_estimate(insight::get_parameters(x, component = component), centrality = centrality, dispersion = dispersion, ...)
 }

--- a/R/print.bayesfactor_inclusion.R
+++ b/R/print.bayesfactor_inclusion.R
@@ -10,7 +10,7 @@ print.bayesfactor_inclusion <- function(x, digits = 3, log = FALSE, ...) {
   }
   BFE$BF <- insight::format_value(BFE$BF, digits = digits, missing = "NA")
   BFE <- cbind(rownames(BFE), BFE)
-  colnames(BFE) <- c("","Pr(prior)", "Pr(posterior)", "Inclusion BF")
+  colnames(BFE) <- c("", "Pr(prior)", "Pr(posterior)", "Inclusion BF")
 
 
   # footer
@@ -23,7 +23,8 @@ print.bayesfactor_inclusion <- function(x, digits = 3, log = FALSE, ...) {
   )
 
   cat(insight::export_table(
-    BFE, digits = digits, sep = " ", header = NULL,
+    BFE,
+    digits = digits, sep = " ", header = NULL,
     caption = c("# Inclusion Bayes Factors (Model Averaged)", "blue"),
     footer = footer
   ))

--- a/R/print.bayesfactor_models.R
+++ b/R/print.bayesfactor_models.R
@@ -15,10 +15,10 @@ print.bayesfactor_models <- function(x, digits = 3, log = FALSE, ...) {
   BFE$Model <- paste0(" [", seq_len(nrow(BFE)), "] ", BFE$Model)
 
   # Denominator
-  if(is.numeric(denominator)) {
+  if (is.numeric(denominator)) {
     denM <- .trim(BFE$Model[denominator])
     BFE <- BFE[-denominator, ]
-  } else{
+  } else {
     denM <- tools::toTitleCase(denominator)
   }
 
@@ -36,8 +36,8 @@ print.bayesfactor_models <- function(x, digits = 3, log = FALSE, ...) {
     BFE,
     sep = " ", header = NULL, align = c("left", "right"),
     caption = c("# Bayes Factors for Model Comparison", "blue"),
-    footer = footer)
-  )
+    footer = footer
+  ))
 
   invisible(x)
 }

--- a/R/print.bayesfactor_parameters.R
+++ b/R/print.bayesfactor_parameters.R
@@ -28,10 +28,11 @@ print.bayesfactor_parameters <- function(x, digits = 3, log = FALSE, ...) {
     insight::print_color(caption[1], caption[2])
     print_data_frame(BFE, digits = digits)
     lapply(footer, function(txt) {
-      if (length(txt) == 2)
+      if (length(txt) == 2) {
         insight::print_color(txt[1], txt[2])
-      else
+      } else {
         cat(txt)
+      }
       NULL
     })
   }

--- a/R/print.bayesfactor_restricted.R
+++ b/R/print.bayesfactor_restricted.R
@@ -17,7 +17,8 @@ print.bayesfactor_restricted <- function(x, digits = 3, log = FALSE, ...) {
 
 
   cat(insight::export_table(
-    BFE, digits = digits, sep = " ", header = NULL,
+    BFE,
+    digits = digits, sep = " ", header = NULL,
     caption = c("# Bayes Factor (Order-Restriction)", "blue"),
     footer = footer
   ))

--- a/R/print.ci.R
+++ b/R/print.ci.R
@@ -73,7 +73,6 @@ print.bayestestR_ci <- function(x, digits = 2, ...) {
 
 #' @export
 as.list.bayestestR_hdi <- function(x, ...) {
-
   if (nrow(x) == 1) {
     out <- list(CI = x$CI, CI_low = x$CI_low, CI_high = x$CI_high)
     out$Parameter <- x$Parameter

--- a/R/rope.R
+++ b/R/rope.R
@@ -399,8 +399,7 @@ rope.sim.merMod <- function(x, range = "default", ci = .89, ci_method = "HDI", e
 
   dat <- do.call(rbind, args = c(.compact_list(list), make.row.names = FALSE))
 
-  dat <- switch(
-    effects,
+  dat <- switch(effects,
     fixed = .select_rows(dat, "Group", "fixed"),
     random = .select_rows(dat, "Group", "random"),
     dat

--- a/R/rope_range.R
+++ b/R/rope_range.R
@@ -181,7 +181,9 @@ rope_range.mlm <- function(x, verbose = TRUE, ...) {
         # Linear Models
         if (isTRUE(verbose)) {
           warning("Note that the default rope range for linear models might change in future versions (see https://github.com/easystats/bayestestR/issues/364).",
-                  "Please set it explicitly to preserve current results.", call. = FALSE)
+            "Please set it explicitly to preserve current results.",
+            call. = FALSE
+          )
         }
         # 0.1 * stats::sigma(x) # https://github.com/easystats/bayestestR/issues/364
         0.1 * stats::sd(response, na.rm = TRUE)

--- a/R/utils_bayesfactor.R
+++ b/R/utils_bayesfactor.R
@@ -273,7 +273,7 @@
       # 3. direction?
       if (direction > 0) {
         d_points <- d_points[d_points$x >= min(null), , drop = FALSE]
-        if (is.infinite(min(null))){
+        if (is.infinite(min(null))) {
           norm_factor <- 1
         } else {
           norm_factor <- 1 - logspline::plogspline(min(null), f_x)
@@ -282,7 +282,7 @@
         d_null$y <- d_null$y / norm_factor
       } else if (direction < 0) {
         d_points <- d_points[d_points$x <= max(null), , drop = FALSE]
-        if (is.infinite(max(null))){
+        if (is.infinite(max(null))) {
           norm_factor <- 1
         } else {
           norm_factor <- logspline::plogspline(max(null), f_x)

--- a/R/utils_get_parameter_names.R
+++ b/R/utils_get_parameter_names.R
@@ -2,8 +2,7 @@
 .get_parameter_names <- function(posterior, effects, component, parameters) {
   pars <- insight::find_parameters(posterior, flatten = FALSE, parameters = parameters)
 
-  pars <- switch(
-    effects,
+  pars <- switch(effects,
     "fixed" = pars[c("conditional", "zero_inflated")],
     "random" = pars[c("random", "zero_inflated_random")],
     "simplex" = pars["simplex"],
@@ -11,8 +10,7 @@
     "all" = pars
   )
 
-  pars <- switch(
-    component,
+  pars <- switch(component,
     "conditional" = pars[c("conditional", "random", "simplex", "smooth_terms")],
     "zi" = ,
     "zero_inflated" = pars[c("zero_inflated", "zero_inflated_random", "simplex", "smooth_terms")],

--- a/R/utils_print_data_frame.R
+++ b/R/utils_print_data_frame.R
@@ -17,8 +17,7 @@ print_data_frame <- function(x, digits) {
   }
 
   for (i in names(out)) {
-    header <- switch(
-      i,
+    header <- switch(i,
       "conditional" = ,
       "fixed_conditional" = ,
       "fixed" = "# Fixed Effects (Conditional Model)",

--- a/paper/Figure1.R
+++ b/paper/Figure1.R
@@ -24,18 +24,18 @@ label_y2 <- ypos2 + .01
 label_x3 <- m3 + .8
 label_y3 <- ypos3 + .01
 
-ggplot(dat, aes(x=x, y=y)) +
-  geom_ribbon(aes(ymin=0, ymax=y), fill="#FFC107") +
-  geom_vline(xintercept=0, linetype="dotted") +
-  geom_segment(x=m2, xend=m2, y=0, yend=ypos2, color="#E91E63", size=1) +
-  geom_point(x=m2, y=ypos2, color="#E91E63", size=5) +
-  geom_label(x = label_x2, y = label_y2, label = "MAP", color="#E91E63", size = 7) +
-  geom_segment(x=m, xend=m, y=0, yend=ypos, color="#2196F3", size=1) +
-  geom_point(x=m, y=ypos, color="#2196F3", size=5) +
-  geom_label(x = label_x, y = label_y, label = "Median", color="#2196F3", size = 7) +
-  geom_segment(x=m3, xend=m3, y=0, yend=ypos3, color="#4CAF50", size=1) +
-  geom_point(x=m3, y=ypos3, color="#4CAF50", size=5) +
-  geom_label(x = label_x3, y = label_y3, label = "Mean", color="#4CAF50", size = 7) +
+ggplot(dat, aes(x = x, y = y)) +
+  geom_ribbon(aes(ymin = 0, ymax = y), fill = "#FFC107") +
+  geom_vline(xintercept = 0, linetype = "dotted") +
+  geom_segment(x = m2, xend = m2, y = 0, yend = ypos2, color = "#E91E63", size = 1) +
+  geom_point(x = m2, y = ypos2, color = "#E91E63", size = 5) +
+  geom_label(x = label_x2, y = label_y2, label = "MAP", color = "#E91E63", size = 7) +
+  geom_segment(x = m, xend = m, y = 0, yend = ypos, color = "#2196F3", size = 1) +
+  geom_point(x = m, y = ypos, color = "#2196F3", size = 5) +
+  geom_label(x = label_x, y = label_y, label = "Median", color = "#2196F3", size = 7) +
+  geom_segment(x = m3, xend = m3, y = 0, yend = ypos3, color = "#4CAF50", size = 1) +
+  geom_point(x = m3, y = ypos3, color = "#4CAF50", size = 5) +
+  geom_label(x = label_x3, y = label_y3, label = "Mean", color = "#4CAF50", size = 7) +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0), limits = c(0, .25)) +
   xlab("\nParameter Value") +

--- a/paper/Figure2.R
+++ b/paper/Figure2.R
@@ -1,36 +1,40 @@
 library(bayestestR)
 library(tidyverse)
-library(strengejacke)  # What the hell is that ^^
+library(strengejacke) # What the hell is that ^^
 library(ggplot2)
 
 set.seed(123)
 posterior <- distribution_chisquared(100, 3)
 dat <- as.data.frame(density(posterior))
 
-p1 <- dat %>% mutate(fill = ifelse(x < hdi(posterior)$CI_low, "low",
-                     ifelse(x > hdi(posterior)$CI_high, "high", "middle"))) %>%
-  ggplot(aes(x=x, y=y, fill=fill)) +
-  geom_ribbon(aes(ymin=0, ymax=y)) +
-  geom_vline(xintercept=0, linetype="dotted") +
+p1 <- dat %>%
+  mutate(fill = ifelse(x < hdi(posterior)$CI_low, "low",
+    ifelse(x > hdi(posterior)$CI_high, "high", "middle")
+  )) %>%
+  ggplot(aes(x = x, y = y, fill = fill)) +
+  geom_ribbon(aes(ymin = 0, ymax = y)) +
+  geom_vline(xintercept = 0, linetype = "dotted") +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0), limits = c(0, .25)) +
-  scale_fill_manual(values=c("high"="#FFC107", "low"="#FFC107", "middle"="#E91E63"), guide=FALSE) +
-  annotate("text", x=2.5, y=.05, label="The 89% HDI", color="white", size=10) +
+  scale_fill_manual(values = c("high" = "#FFC107", "low" = "#FFC107", "middle" = "#E91E63"), guide = FALSE) +
+  annotate("text", x = 2.5, y = .05, label = "The 89% HDI", color = "white", size = 10) +
   xlab(NULL) +
   ylab("Probability Density\n")
 
 # ggsave("paper/Figure2.png", width = 13, height = 8, units = "in", dpi = 300)
 
 
-p2 <- dat %>% mutate(fill = ifelse(x < ci(posterior)$CI_low, "low",
-                             ifelse(x > ci(posterior)$CI_high, "high", "middle"))) %>%
-  ggplot(aes(x=x, y=y, fill=fill)) +
-  geom_ribbon(aes(ymin=0, ymax=y)) +
-  geom_vline(xintercept=0, linetype="dotted") +
+p2 <- dat %>%
+  mutate(fill = ifelse(x < ci(posterior)$CI_low, "low",
+    ifelse(x > ci(posterior)$CI_high, "high", "middle")
+  )) %>%
+  ggplot(aes(x = x, y = y, fill = fill)) +
+  geom_ribbon(aes(ymin = 0, ymax = y)) +
+  geom_vline(xintercept = 0, linetype = "dotted") +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0), limits = c(0, .25)) +
-  scale_fill_manual(values=c("high"="#FFC107", "low"="#FFC107", "middle"="#2196F3"), guide=FALSE) +
-  annotate("text", x=2.9, y=.05, label="The 89% ETI", color="white", size=10) +
+  scale_fill_manual(values = c("high" = "#FFC107", "low" = "#FFC107", "middle" = "#2196F3"), guide = FALSE) +
+  annotate("text", x = 2.9, y = .05, label = "The 89% ETI", color = "white", size = 10) +
   xlab("\nParameter Value") +
   ylab("Probability Density\n")
 

--- a/paper/Figure3.R
+++ b/paper/Figure3.R
@@ -9,14 +9,16 @@ set.seed(123)
 posterior <- distribution_chisquared(100, 3)
 dat <- as.data.frame(density(posterior))
 
-p1 <- dat %>% mutate(fill = ifelse(x < -.5, "low",
-                             ifelse(x > .5, "high", "middle"))) %>%
-  ggplot(aes(x=x, y=y, fill=fill)) +
-  geom_ribbon(aes(ymin=0, ymax=y)) +
-  geom_vline(xintercept=0, linetype="dotted") +
+p1 <- dat %>%
+  mutate(fill = ifelse(x < -.5, "low",
+    ifelse(x > .5, "high", "middle")
+  )) %>%
+  ggplot(aes(x = x, y = y, fill = fill)) +
+  geom_ribbon(aes(ymin = 0, ymax = y)) +
+  geom_vline(xintercept = 0, linetype = "dotted") +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0), limits = c(0, .25)) +
-  scale_fill_manual(values=c("high"="#FFC107", "low"="#FFC107", "middle"="#E91E63"), guide=FALSE) +
+  scale_fill_manual(values = c("high" = "#FFC107", "low" = "#FFC107", "middle" = "#E91E63"), guide = FALSE) +
   ggtitle("Region of Practical Equivalence (ROPE)") +
   theme(plot.title = element_text(hjust = 0.5, size = 18, face = "italic")) +
   xlab(NULL) +
@@ -31,12 +33,12 @@ p2 <- posterior %>%
   density() %>%
   as.data.frame() %>%
   mutate(fill = ifelse(x < 0, "low", "high")) %>%
-  ggplot(aes(x=x, y=y, fill=fill)) +
-  geom_ribbon(aes(ymin=0, ymax=y)) +
-  geom_vline(xintercept=0, linetype="dotted") +
+  ggplot(aes(x = x, y = y, fill = fill)) +
+  geom_ribbon(aes(ymin = 0, ymax = y)) +
+  geom_vline(xintercept = 0, linetype = "dotted") +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0), limits = c(0, 2)) +
-  scale_fill_manual(values=c("high"="#FFC107", "low"="#E91E63"), guide=FALSE) +
+  scale_fill_manual(values = c("high" = "#FFC107", "low" = "#E91E63"), guide = FALSE) +
   ggtitle("Probability of Direction (pd)") +
   theme(plot.title = element_text(hjust = 0.5, size = 18, face = "italic")) +
   xlab(NULL) +
@@ -54,16 +56,16 @@ prior <- distribution_normal(1000, mean = 0, sd = 1) %>%
   as.data.frame()
 
 p3 <- posterior %>%
-  ggplot(aes(x=x, y=y)) +
-  geom_ribbon(aes(ymin=0, ymax=y), fill="#FFC107") +
-  geom_line(data=prior, size=1, linetype="dotted") +
-  geom_segment(x=0, xend=0, y=0, yend=max(prior$y), color="#2196F3", size=1) +
-  geom_point(x=0, y=max(prior$y), color="#2196F3", size=5) +
-  geom_segment(x=0, xend=0, y=0, yend=density_at(posterior$x, 0, bw="nrd0"), color="#E91E63", size=1) +
-  geom_point(x=0, y=density_at(posterior$x, 0, bw="nrd0"), color="#E91E63", size=5) +
+  ggplot(aes(x = x, y = y)) +
+  geom_ribbon(aes(ymin = 0, ymax = y), fill = "#FFC107") +
+  geom_line(data = prior, size = 1, linetype = "dotted") +
+  geom_segment(x = 0, xend = 0, y = 0, yend = max(prior$y), color = "#2196F3", size = 1) +
+  geom_point(x = 0, y = max(prior$y), color = "#2196F3", size = 5) +
+  geom_segment(x = 0, xend = 0, y = 0, yend = density_at(posterior$x, 0, bw = "nrd0"), color = "#E91E63", size = 1) +
+  geom_point(x = 0, y = density_at(posterior$x, 0, bw = "nrd0"), color = "#E91E63", size = 5) +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0), limits = c(0, 0.65)) +
-  scale_fill_manual(values=c("high"="#FFC107", "low"="#E91E63"), guide=FALSE) +
+  scale_fill_manual(values = c("high" = "#FFC107", "low" = "#E91E63"), guide = FALSE) +
   ggtitle("Bayes factor") +
   theme(plot.title = element_text(hjust = 0.5, size = 18, face = "italic")) +
   xlab(NULL) +
@@ -111,17 +113,25 @@ set.seed(123)
 #   xlab(NULL) +
 #   ylab(NULL)
 
-x <- seq(-4,4, length.out = 1000)
-posterior <- data.frame(x = x,
-                        y = dnorm(x, 1,0.7),
-                        fill = case_when(x < -.5 ~ "-out1",
-                                         x > 0.5 ~ "+out1",
-                                         TRUE    ~ "in1"))
-prior <- data.frame(x = x,
-                        y = dnorm(x, 0,1),
-                        fill = case_when(x < -.5 ~ "-out2",
-                                         x > 0.5 ~ "+out2",
-                                         TRUE    ~ "in2"))
+x <- seq(-4, 4, length.out = 1000)
+posterior <- data.frame(
+  x = x,
+  y = dnorm(x, 1, 0.7),
+  fill = case_when(
+    x < -.5 ~ "-out1",
+    x > 0.5 ~ "+out1",
+    TRUE ~ "in1"
+  )
+)
+prior <- data.frame(
+  x = x,
+  y = dnorm(x, 0, 1),
+  fill = case_when(
+    x < -.5 ~ "-out2",
+    x > 0.5 ~ "+out2",
+    TRUE ~ "in2"
+  )
+)
 
 # alpha
 ribalpha <- 0.8
@@ -129,12 +139,16 @@ ribalpha <- 0.8
 
 
 ggplot() +
-  geom_ribbon(data = posterior,
-              aes(x = x, fill = fill, ymin = 0, ymax = y), alpha = ribalpha) +
-  geom_ribbon(data = prior,
-              aes(x = x, fill = fill, ymin = 0, ymax = y), alpha = ribalpha) +
+  geom_ribbon(
+    data = posterior,
+    aes(x = x, fill = fill, ymin = 0, ymax = y), alpha = ribalpha
+  ) +
+  geom_ribbon(
+    data = prior,
+    aes(x = x, fill = fill, ymin = 0, ymax = y), alpha = ribalpha
+  ) +
   geom_line(data = prior, aes(x = x, y = y), color = "black", linetype = "dotted", size = 1) +
-  geom_vline(xintercept=c(-.5,.5), linetype="solid") +
+  geom_vline(xintercept = c(-.5, .5), linetype = "solid") +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0)) +
   scale_x_continuous(expand = c(0, 0)) +
@@ -146,8 +160,8 @@ ggplot() +
       "+out2" = NA,
       "in1" = "#E91E63",
       "in2" = "#2196F3"
-    )
-    ,guide = FALSE
+    ),
+    guide = FALSE
   ) +
   ggtitle("Bayes factor (ROPE)") +
   theme(plot.title = element_text(hjust = 0.5, size = 18, face = "italic")) +
@@ -166,13 +180,13 @@ ypos2 <- dat$y[which.min(abs(dat$x - m2))]
 
 ypos_null <- dat$y[which.min(abs(dat$x))]
 
-p4 <- ggplot(dat, aes(x=x, y=y)) +
-  geom_ribbon(aes(ymin=0, ymax=y), fill="#FFC107") +
-  geom_segment(x=m2, xend=m2, y=0, yend=ypos2, color="#E91E63", size=1) +
-  geom_point(x=m2, y=ypos2, color="#E91E63", size=5) +
-  geom_segment(x=0, xend=0, y=0, yend=ypos_null, color="#E91E63", size=1) +
-  geom_point(x=0, y=ypos_null, color="#E91E63", size=5) +
-  geom_vline(xintercept=0, linetype="dotted") +
+p4 <- ggplot(dat, aes(x = x, y = y)) +
+  geom_ribbon(aes(ymin = 0, ymax = y), fill = "#FFC107") +
+  geom_segment(x = m2, xend = m2, y = 0, yend = ypos2, color = "#E91E63", size = 1) +
+  geom_point(x = m2, y = ypos2, color = "#E91E63", size = 5) +
+  geom_segment(x = 0, xend = 0, y = 0, yend = ypos_null, color = "#E91E63", size = 1) +
+  geom_point(x = 0, y = ypos_null, color = "#E91E63", size = 5) +
+  geom_vline(xintercept = 0, linetype = "dotted") +
   theme_classic(base_size = 20) +
   scale_y_continuous(expand = c(0, 0), limits = c(0, .25)) +
   ggtitle("MAP-based p-value") +

--- a/paper/Figure4.R
+++ b/paper/Figure4.R
@@ -31,4 +31,4 @@ p <- x %>%
   scale_fill_manual(values = c("Negative" = "#E91E63", "Positive" = "#4CAF50")) +
   theme(plot.title = element_text(hjust = 0.5))
 p
-ggsave("Figure4.png", plot = p, width = 13*0.7, height = 8*0.7, units = "in", dpi = 450)
+ggsave("Figure4.png", plot = p, width = 13 * 0.7, height = 8 * 0.7, units = "in", dpi = 450)

--- a/tests/testthat/test-BFBayesFactor.R
+++ b/tests/testthat/test-BFBayesFactor.R
@@ -2,7 +2,7 @@ if (require("testthat") && require("BayesFactor") && require("bayestestR")) {
   set.seed(333)
   x <- BayesFactor::correlationBF(y = iris$Sepal.Length, x = iris$Sepal.Width)
   test_that("p_direction", {
-    expect_equal(as.numeric(p_direction(x)), 0.9225, tol = 1)
+    expect_equal(as.numeric(p_direction(x)), 0.9225, tolerance = 1)
   })
 
 
@@ -11,7 +11,7 @@ if (require("testthat") && require("BayesFactor") && require("bayestestR")) {
   diffScores <- sleep$extra[1:10] - sleep$extra[11:20]
   x <- BayesFactor::ttestBF(x = diffScores)
   test_that("p_direction", {
-    expect_equal(as.numeric(p_direction(x)), 0.99675, tol = 1)
+    expect_equal(as.numeric(p_direction(x)), 0.99675, tolerance = 1)
   })
 
 
@@ -21,7 +21,7 @@ if (require("testthat") && require("BayesFactor") && require("bayestestR")) {
   chickwts$feed <- factor(chickwts$feed)
   x <- BayesFactor::ttestBF(formula = weight ~ feed, data = chickwts)
   test_that("p_direction", {
-    expect_equal(as.numeric(p_direction(x)), 1, tol = 1)
+    expect_equal(as.numeric(p_direction(x)), 1, tolerance = 1)
   })
 
   # BF t.test meta-analytic ---------------------------
@@ -29,11 +29,11 @@ if (require("testthat") && require("BayesFactor") && require("bayestestR")) {
   N <- c(100, 150, 97, 99)
   x <- BayesFactor::meta.ttestBF(t = t, n1 = N, rscale = 1)
   test_that("p_direction", {
-    expect_equal(as.numeric(p_direction(x)), 0.99975, tol = 1)
+    expect_equal(as.numeric(p_direction(x)), 0.99975, tolerance = 1)
   })
 
   # # ---------------------------
-  # context("BF ANOVA")
+  # # "BF ANOVA"
   # data(ToothGrowth)
   # ToothGrowth$dose <- factor(ToothGrowth$dose)
   # levels(ToothGrowth$dose) <- c("Low", "Medium", "High")
@@ -43,7 +43,7 @@ if (require("testthat") && require("BayesFactor") && require("bayestestR")) {
   # })
   #
   # # ---------------------------
-  # context("BF ANOVA Random")
+  # # "BF ANOVA Random"
   # data(puzzles)
   # x <- BayesFactor::anovaBF(RT ~ shape*color + ID, data = puzzles, whichRandom="ID")
   # test_that("p_direction", {
@@ -52,7 +52,7 @@ if (require("testthat") && require("BayesFactor") && require("bayestestR")) {
   #
   #
   # # ---------------------------
-  # context("BF lm")
+  # # "BF lm"
   # x <- BayesFactor::lmBF(len ~ supp + dose, data = ToothGrowth)
   # test_that("p_direction", {
   #   expect_equal(as.numeric(p_direction(x)), 91.9, tol=0.1)

--- a/tests/testthat/test-as.data.frame.density.R
+++ b/tests/testthat/test-as.data.frame.density.R
@@ -1,5 +1,3 @@
-context("as.data.frame.density")
-
 test_that("as.data.frame.density", {
-  testthat::expect_is(as.data.frame(density(distribution_normal(1000))), "data.frame")
+  expect_s3_class(as.data.frame(density(distribution_normal(1000))), "data.frame")
 })

--- a/tests/testthat/test-bayesfactor_models.R
+++ b/tests/testthat/test-bayesfactor_models.R
@@ -19,7 +19,7 @@ if (require("bayestestR") && require("testthat")) {
 
     expect_equal(BFM1, BFM2)
     expect_equal(BFM1, BFM3)
-    expect_equal(BFM1, bayestestR::bayesfactor_models(list(mo2=mo2, mo3=mo3, mo4=mo4, mo1=mo1), denominator = 4))
+    expect_equal(BFM1, bayestestR::bayesfactor_models(list(mo2 = mo2, mo3 = mo3, mo4 = mo4, mo1 = mo1), denominator = 4))
 
     # only on same data!
     expect_error(bayestestR::bayesfactor_models(mo1, mo2, mo4_e))

--- a/tests/testthat/test-bayesfactor_models.R
+++ b/tests/testthat/test-bayesfactor_models.R
@@ -85,9 +85,9 @@ if (require("bayestestR") && require("testthat")) {
 
     set.seed(333)
     expect_warning(stan_models <- bayesfactor_models(stan_bf_0, stan_bf_1))
-    expect_is(stan_models, "bayesfactor_models")
+    expect_s3_class(stan_models, "bayesfactor_models")
     expect_equal(length(log(stan_models$BF)), 2)
-    expect_equal(log(stan_models$BF[2]), log(bridge_BF$bf), tol = 0.1)
+    expect_equal(log(stan_models$BF[2]), log(bridge_BF$bf), tolerance = 0.1)
   })
 
 

--- a/tests/testthat/test-bayesfactor_restricted.R
+++ b/tests/testthat/test-bayesfactor_restricted.R
@@ -38,7 +38,7 @@ if (require("rstanarm") &&
 
   test_that("bayesfactor_restricted RSTANARM", {
     skip_on_cran()
-    fit_stan <- stan_glm(mpg ~ wt + cyl + am, data = mtcars, refresh = 0, iter=200)
+    fit_stan <- stan_glm(mpg ~ wt + cyl + am, data = mtcars, refresh = 0, iter = 200)
 
     hyps <- c(
       "am > 0 & cyl < 0",

--- a/tests/testthat/test-brms.R
+++ b/tests/testthat/test-brms.R
@@ -25,10 +25,10 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
       "pd", "ROPE_CI", "ROPE_low", "ROPE_high", "ROPE_Percentage",
       "Rhat", "ESS"
     ))
-    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[1:2],tolerance = 1e-3)
-    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[1:2],tolerance = 1e-1)
-    expect_equal(as.vector(s$random$cyl[, 1, drop = TRUE]), out$Mean[12],tolerance = 1e-3)
-    expect_equal(as.vector(s$random$gear[, 1, drop = TRUE]), out$Mean[13:15],tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[1:2], tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[1:2], tolerance = 1e-1)
+    expect_equal(as.vector(s$random$cyl[, 1, drop = TRUE]), out$Mean[12], tolerance = 1e-3)
+    expect_equal(as.vector(s$random$gear[, 1, drop = TRUE]), out$Mean[13:15], tolerance = 1e-3)
   })
 
   test_that("brms", {
@@ -44,8 +44,8 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
       "Parameter", "Mean", "CI", "CI_low", "CI_high", "pd", "ROPE_CI",
       "ROPE_low", "ROPE_high", "ROPE_Percentage", "Rhat", "ESS"
     ))
-    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[1:3],tolerance = 1e-3)
-    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[1:3],tolerance = 1e-1)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[1:3], tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[1:3], tolerance = 1e-1)
   })
 
   test_that("brms", {
@@ -61,8 +61,8 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
       "Parameter", "Effects", "Mean", "CI", "CI_low", "CI_high",
       "Rhat", "ESS"
     ))
-    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[c(1, 11, 2:5, 12:14)],tolerance = 1e-3)
-    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[c(1, 11, 2:5, 12:14)],tolerance = 1e-1)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[c(1, 11, 2:5, 12:14)], tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[c(1, 11, 2:5, 12:14)], tolerance = 1e-1)
   })
 
   test_that("brms", {
@@ -74,7 +74,7 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
 
     out <- describe_posterior(model, effects = "all", components = "all", centrality = "mean", test = NULL)
     s <- summary(model)
-    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean,tolerance = 1e-3)
-    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat,tolerance = 1e-1)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean, tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat, tolerance = 1e-1)
   })
 }

--- a/tests/testthat/test-brms.R
+++ b/tests/testthat/test-brms.R
@@ -5,14 +5,14 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
     set.seed(333)
     model <- insight::download_model("brms_mixed_1")
 
-    expect_is(hdi(model), "data.frame")
-    expect_is(ci(model), "data.frame")
-    expect_is(rope(model), "data.frame")
+    expect_s3_class(hdi(model), "data.frame")
+    expect_s3_class(ci(model), "data.frame")
+    expect_s3_class(rope(model), "data.frame")
     # expect_true("equivalence_test" %in% class(equivalence_test(model)))
-    expect_is(map_estimate(model), "data.frame")
-    expect_is(p_map(model), "data.frame")
-    expect_is(mhdior(model), "data.frame")
-    expect_is(p_direction(model), "data.frame")
+    expect_s3_class(map_estimate(model), "data.frame")
+    expect_s3_class(p_map(model), "data.frame")
+    expect_s3_class(mhdior(model), "data.frame")
+    expect_s3_class(p_direction(model), "data.frame")
 
     expect_equal(colnames(hdi(model)), c("Parameter", "CI", "CI_low", "CI_high", "Effects", "Component"))
     expect_equal(colnames(hdi(model, effects = "all")), c("Parameter", "CI", "CI_low", "CI_high", "Effects", "Component"))
@@ -25,10 +25,10 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
       "pd", "ROPE_CI", "ROPE_low", "ROPE_high", "ROPE_Percentage",
       "Rhat", "ESS"
     ))
-    expect_equal(s$fixed[, 1, drop = TRUE], out$Mean[1:2], check.attributes = FALSE, tolerance = 1e-3)
-    expect_equal(s$fixed[, 5, drop = TRUE], out$Rhat[1:2], check.attributes = FALSE, tolerance = 1e-1)
-    expect_equal(s$random$cyl[, 1, drop = TRUE], out$Mean[12], check.attributes = FALSE, tolerance = 1e-3)
-    expect_equal(s$random$gear[, 1, drop = TRUE], out$Mean[13:15], check.attributes = FALSE, tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[1:2],tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[1:2],tolerance = 1e-1)
+    expect_equal(as.vector(s$random$cyl[, 1, drop = TRUE]), out$Mean[12],tolerance = 1e-3)
+    expect_equal(as.vector(s$random$gear[, 1, drop = TRUE]), out$Mean[13:15],tolerance = 1e-3)
   })
 
   test_that("brms", {
@@ -44,8 +44,8 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
       "Parameter", "Mean", "CI", "CI_low", "CI_high", "pd", "ROPE_CI",
       "ROPE_low", "ROPE_high", "ROPE_Percentage", "Rhat", "ESS"
     ))
-    expect_equal(s$fixed[, 1, drop = TRUE], out$Mean[1:3], check.attributes = FALSE, tolerance = 1e-3)
-    expect_equal(s$fixed[, 5, drop = TRUE], out$Rhat[1:3], check.attributes = FALSE, tolerance = 1e-1)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[1:3],tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[1:3],tolerance = 1e-1)
   })
 
   test_that("brms", {
@@ -61,8 +61,8 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
       "Parameter", "Effects", "Mean", "CI", "CI_low", "CI_high",
       "Rhat", "ESS"
     ))
-    expect_equal(s$fixed[, 1, drop = TRUE], out$Mean[c(1, 11, 2:5, 12:14)], check.attributes = FALSE, tolerance = 1e-3)
-    expect_equal(s$fixed[, 5, drop = TRUE], out$Rhat[c(1, 11, 2:5, 12:14)], check.attributes = FALSE, tolerance = 1e-1)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean[c(1, 11, 2:5, 12:14)],tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat[c(1, 11, 2:5, 12:14)],tolerance = 1e-1)
   })
 
   test_that("brms", {
@@ -74,7 +74,7 @@ if (require("brms") && require("testthat") && require("insight") && require("htt
 
     out <- describe_posterior(model, effects = "all", components = "all", centrality = "mean", test = NULL)
     s <- summary(model)
-    expect_equal(s$fixed[, 1, drop = TRUE], out$Mean, check.attributes = FALSE, tolerance = 1e-3)
-    expect_equal(s$fixed[, 5, drop = TRUE], out$Rhat, check.attributes = FALSE, tolerance = 1e-1)
+    expect_equal(as.vector(s$fixed[, 1, drop = TRUE]), out$Mean,tolerance = 1e-3)
+    expect_equal(as.vector(s$fixed[, 5, drop = TRUE]), out$Rhat,tolerance = 1e-1)
   })
 }

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -1,4 +1,4 @@
-if (require("rstanarm") && require("httr") && require("brms") && require("insight") &&require("testthat")) {
+if (require("rstanarm") && require("httr") && require("brms") && require("insight") && require("testthat")) {
   test_that("ci", {
     expect_equal(ci(distribution_normal(1000), ci = .90)$CI_low[1], -1.6361, tolerance = 0.02)
     expect_equal(nrow(ci(distribution_normal(1000), ci = c(.80, .90, .95))), 3, tolerance = 0.01)

--- a/tests/testthat/test-density_at.R
+++ b/tests/testthat/test-density_at.R
@@ -1,4 +1,4 @@
 test_that("density_at", {
-  testthat::expect_equal(density_at(distribution_normal(1000), 0), 0.389, tolerance = 0.01)
-  testthat::expect_equal(density_at(distribution_normal(1000), c(0, 1))[1], 0.389, tolerance = 0.01)
+  expect_equal(density_at(distribution_normal(1000), 0), 0.389, tolerance = 0.01)
+  expect_equal(density_at(distribution_normal(1000), c(0, 1))[1], 0.389, tolerance = 0.01)
 })

--- a/tests/testthat/test-density_at.R
+++ b/tests/testthat/test-density_at.R
@@ -1,4 +1,4 @@
 test_that("density_at", {
-  expect_equal(density_at(distribution_normal(1000), 0), 0.389, tolerance = 0.01)
-  expect_equal(density_at(distribution_normal(1000), c(0, 1))[1], 0.389, tolerance = 0.01)
+  expect_equal(density_at(distribution_normal(1000), 0), 0.389, tolerance = 0.1)
+  expect_equal(density_at(distribution_normal(1000), c(0, 1))[1], 0.389, tolerance = 0.1)
 })

--- a/tests/testthat/test-different_models.R
+++ b/tests/testthat/test-different_models.R
@@ -3,33 +3,33 @@ if (require("bayesQR", quietly = TRUE)) {
     x <- bayesQR::bayesQR(Sepal.Length ~ Petal.Width, data = iris, quantile = 0.1, alasso = TRUE, ndraw = 500)
 
     rez <- p_direction(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
 
     rez <- p_map(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
 
     rez <- p_significance(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
 
     rez <- rope(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 5))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 5))
 
     rez <- hdi(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 4))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 4))
 
     rez <- eti(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 4))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 4))
 
     rez <- map_estimate(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 2))
 
     rez <- point_estimate(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 4))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 4))
 
     rez <- describe_posterior(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2, 10))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2, 10))
 
     rez <- estimate_density(x)
-    testthat::expect_equal(c(nrow(rez), ncol(rez)), c(2048, 3))
+    expect_equal(c(nrow(rez), ncol(rez)), c(2048, 3))
   })
 }

--- a/tests/testthat/test-distributions.R
+++ b/tests/testthat/test-distributions.R
@@ -1,30 +1,28 @@
-context("distributions")
-
 test_that("distributions", {
-  testthat::expect_equal(mean(bayestestR::distribution_normal(10)), 0, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_normal(10, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_normal(10)), 0, tolerance = 0.01)
+  expect_equal(length(distribution_normal(10, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_beta(10, 1, 1)), 0.5, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_normal(10, 1, 1, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_beta(10, 1, 1)), 0.5, tolerance = 0.01)
+  expect_equal(length(distribution_normal(10, 1, 1, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_binomial(10, 0, 0.5)), 0, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_binomial(10, 0, 0.5, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_binomial(10, 0, 0.5)), 0, tolerance = 0.01)
+  expect_equal(length(distribution_binomial(10, 0, 0.5, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_cauchy(10)), 0, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_cauchy(10, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_cauchy(10)), 0, tolerance = 0.01)
+  expect_equal(length(distribution_cauchy(10, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_chisquared(10, 1)), 0.778, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_chisquared(10, 1, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_chisquared(10, 1)), 0.778, tolerance = 0.01)
+  expect_equal(length(distribution_chisquared(10, 1, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_gamma(10, 1)), 0.874, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_gamma(10, 1, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_gamma(10, 1)), 0.874, tolerance = 0.01)
+  expect_equal(length(distribution_gamma(10, 1, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_poisson(10)), 0.8, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_poisson(10, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_poisson(10)), 0.8, tolerance = 0.01)
+  expect_equal(length(distribution_poisson(10, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_student(10, 1)), 0, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_student(10, 1, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_student(10, 1)), 0, tolerance = 0.01)
+  expect_equal(length(distribution_student(10, 1, random = TRUE)), 10, tolerance = 0.01)
 
-  testthat::expect_equal(mean(bayestestR::distribution_uniform(10)), 0.5, tolerance = 0.01)
-  testthat::expect_equal(length(bayestestR::distribution_uniform(10, random = TRUE)), 10, tolerance = 0.01)
+  expect_equal(mean(distribution_uniform(10)), 0.5, tolerance = 0.01)
+  expect_equal(length(distribution_uniform(10, random = TRUE)), 10, tolerance = 0.01)
 })

--- a/tests/testthat/test-effective_sample.R
+++ b/tests/testthat/test-effective_sample.R
@@ -2,7 +2,7 @@ if (require("rstanarm") && require("brms") && require("insight")) {
   test_that("effective_sample", {
     brms_1 <- insight::download_model("brms_1")
     res <- effective_sample(brms_1)
-    testthat::expect_equal(
+    expect_equal(
       res,
       data.frame(
         Parameter = c("b_Intercept", "b_wt", "b_cyl"),
@@ -13,7 +13,7 @@ if (require("rstanarm") && require("brms") && require("insight")) {
 
     brms_null_1 <- insight::download_model("brms_null_1")
     res <- effective_sample(brms_null_1)
-    testthat::expect_equal(
+    expect_equal(
       res,
       data.frame(
         Parameter = c("b_Intercept"),
@@ -24,7 +24,7 @@ if (require("rstanarm") && require("brms") && require("insight")) {
 
     brms_null_2 <- insight::download_model("brms_null_2")
     res <- effective_sample(brms_null_2)
-    testthat::expect_equal(
+    expect_equal(
       res,
       data.frame(
         Parameter = c("b_Intercept"),

--- a/tests/testthat/test-estimate_density.R
+++ b/tests/testthat/test-estimate_density.R
@@ -9,8 +9,8 @@ if (require("logspline") && require("KernSmooth") && require("mclust")) {
     density_KernSmooth <- estimate_density(x, method = "KernSmooth")
     density_mixture <- estimate_density(x, method = "mixture")
 
-    testthat::expect_equal(mean(density_kernel$y - density_logspline$y), 0, tol = 0.1)
-    testthat::expect_equal(mean(density_kernel$y - density_KernSmooth$y), 0, tol = 0.1)
-    testthat::expect_equal(mean(density_kernel$y - density_mixture$y), 0, tol = 0.1)
+    expect_equal(mean(density_kernel$y - density_logspline$y), 0, tolerance = 0.1)
+    expect_equal(mean(density_kernel$y - density_KernSmooth$y), 0, tolerance = 0.1)
+    expect_equal(mean(density_kernel$y - density_mixture$y), 0, tolerance = 0.1)
   })
 }

--- a/tests/testthat/test-map_estimate.R
+++ b/tests/testthat/test-map_estimate.R
@@ -1,6 +1,6 @@
 if (require("testthat") && requireNamespace("rstanarm", quietly = TRUE)) {
   test_that("map_estimate", {
-    testthat::expect_equal(
+    expect_equal(
       as.numeric(map_estimate(distribution_normal(1000))),
       0,
       tolerance = 0.01
@@ -14,7 +14,7 @@ if (require("testthat") && requireNamespace("rstanarm", quietly = TRUE)) {
     m <- insight::download_model("stanreg_merMod_5")
 
     test_that("map_estimate", {
-      testthat::expect_equal(
+      expect_equal(
         map_estimate(m, effects = "all")$Parameter,
         colnames(as.data.frame(m))[1:21]
       )
@@ -23,7 +23,7 @@ if (require("testthat") && requireNamespace("rstanarm", quietly = TRUE)) {
     m <- insight::download_model("brms_zi_3")
 
     test_that("map_estimate", {
-      testthat::expect_equal(
+      expect_equal(
         map_estimate(m, effects = "all", component = "all")$Parameter,
         c(
           "b_Intercept", "b_child", "b_camper", "r_persons.1.Intercept.",

--- a/tests/testthat/test-mhdior.R
+++ b/tests/testthat/test-mhdior.R
@@ -1,9 +1,8 @@
-context("mhdior")
 
 test_that("mhdior", {
-  testthat::expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 5, sd = 1), range = c(-0.1, 0.1))), 1, tolerance = 0.01)
-  testthat::expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 1, sd = 1), range = c(-0.1, 0.1))), 0.631, tolerance = 0.01)
-  testthat::expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = -1, sd = 1), range = c(-0.1, 0.1))), 0.631, tolerance = 0.01)
-  testthat::expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 0, sd = 1), range = c(-0.1, 0.1))), -0.079, tolerance = 0.01)
-  testthat::expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 0, sd = 0.01), range = c(-0.1, 0.1))), -1, tolerance = 0.01)
+  expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 5, sd = 1), range = c(-0.1, 0.1))), 1, tolerance = 0.01)
+  expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 1, sd = 1), range = c(-0.1, 0.1))), 0.631, tolerance = 0.01)
+  expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = -1, sd = 1), range = c(-0.1, 0.1))), 0.631, tolerance = 0.01)
+  expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 0, sd = 1), range = c(-0.1, 0.1))), -0.079, tolerance = 0.01)
+  expect_equal(as.numeric(mhdior(x = distribution_normal(1000, mean = 0, sd = 0.01), range = c(-0.1, 0.1))), -1, tolerance = 0.01)
 })

--- a/tests/testthat/test-overlap.R
+++ b/tests/testthat/test-overlap.R
@@ -1,9 +1,7 @@
-context("overlap")
-
 test_that("overlap", {
   set.seed(333)
   x <- distribution_normal(1000, 2, 0.5)
   y <- distribution_normal(1000, 0, 1)
 
-  testthat::expect_equal(as.numeric(overlap(x, y)), 0.185, tol = 0.01)
+  expect_equal(as.numeric(overlap(x, y)), 0.185, tolerance = 0.01)
 })

--- a/tests/testthat/test-p_direction.R
+++ b/tests/testthat/test-p_direction.R
@@ -3,11 +3,11 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
     set.seed(333)
     x <- bayestestR::distribution_normal(10000, 1, 1)
     pd <- bayestestR::p_direction(x)
-    testthat::expect_equal(as.numeric(pd), 0.842, tolerance = 0.1)
-    testthat::expect_equal(as.numeric(p_direction(x, method = "kernel")), 0.842, tolerance = 0.1)
-    testthat::expect_equal(nrow(p_direction(data.frame(replicate(4, rnorm(100))))), 4)
-    testthat::expect_is(pd, "p_direction")
-    testthat::expect_equal(tail(capture.output(print(pd)), 1), "pd = 84.14%")
+    expect_equal(as.numeric(pd), 0.842, tolerance = 0.1)
+    expect_equal(as.numeric(p_direction(x, method = "kernel")), 0.842, tolerance = 0.1)
+    expect_equal(nrow(p_direction(data.frame(replicate(4, rnorm(100))))), 4)
+    expect_s3_class(pd, "p_direction")
+    expect_equal(tail(capture.output(print(pd)), 1), "pd = 84.14%")
   })
 
 
@@ -17,8 +17,8 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
       m <- insight::download_model("stanreg_merMod_5")
       p <- insight::get_parameters(m, effects = "all")
 
-      testthat::test_that("p_direction", {
-        testthat::expect_equal(
+      test_that("p_direction", {
+        expect_equal(
           p_direction(m, effects = "all")$pd,
           p_direction(p)$pd,
           tolerance = 1e-3
@@ -28,8 +28,8 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
       m <- insight::download_model("brms_zi_3")
       p <- insight::get_parameters(m, effects = "all", component = "all")
 
-      testthat::test_that("p_direction", {
-        testthat::expect_equal(
+      test_that("p_direction", {
+        expect_equal(
           p_direction(m, effects = "all", component = "all")$pd,
           p_direction(p)$pd,
           tolerance = 1e-3

--- a/tests/testthat/test-p_map.R
+++ b/tests/testthat/test-p_map.R
@@ -1,11 +1,9 @@
 if (requireNamespace("rstanarm", quietly = TRUE)) {
-  context("p_map")
-
   test_that("p_map", {
-    testthat::expect_equal(as.numeric(p_map(distribution_normal(1000))), 1, tolerance = 0.01)
-    testthat::expect_equal(as.numeric(p_map(distribution_normal(1000, 1, 1))), 0.62, tolerance = 0.01)
-    testthat::expect_equal(as.numeric(p_map(distribution_normal(1000, 2, 1))), 0.15, tolerance = 0.01)
-    testthat::expect_equal(as.numeric(p_map(distribution_normal(1000, 3, 0.01))), 0, tolerance = 0.01)
+    expect_equal(as.numeric(p_map(distribution_normal(1000))), 1, tolerance = 0.01)
+    expect_equal(as.numeric(p_map(distribution_normal(1000, 1, 1))), 0.62, tolerance = 0.01)
+    expect_equal(as.numeric(p_map(distribution_normal(1000, 2, 1))), 0.15, tolerance = 0.01)
+    expect_equal(as.numeric(p_map(distribution_normal(1000, 3, 0.01))), 0, tolerance = 0.01)
   })
 
 
@@ -16,10 +14,10 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
       p <- insight::get_parameters(m, effects = "all")
 
       test_that("p_map", {
-        testthat::expect_equal(
+        expect_equal(
           p_map(m, effects = "all")$p_MAP,
           p_map(p)$p_MAP,
-          tolerance = 1e-3
+          tolerance = 0.01
         )
       })
 
@@ -27,10 +25,10 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
       p <- insight::get_parameters(m, effects = "all", component = "all")
 
       test_that("p_map", {
-        testthat::expect_equal(
+        expect_equal(
           p_map(m, effects = "all", component = "all")$p_MAP,
           p_map(p)$p_MAP,
-          tolerance = 1e-3
+          tolerance = 0.01
         )
       })
     }

--- a/tests/testthat/test-p_map.R
+++ b/tests/testthat/test-p_map.R
@@ -1,9 +1,9 @@
 if (requireNamespace("rstanarm", quietly = TRUE)) {
   test_that("p_map", {
-    expect_equal(as.numeric(p_map(distribution_normal(1000))), 1, tolerance = 0.01)
-    expect_equal(as.numeric(p_map(distribution_normal(1000, 1, 1))), 0.62, tolerance = 0.01)
-    expect_equal(as.numeric(p_map(distribution_normal(1000, 2, 1))), 0.15, tolerance = 0.01)
-    expect_equal(as.numeric(p_map(distribution_normal(1000, 3, 0.01))), 0, tolerance = 0.01)
+    expect_equal(as.numeric(p_map(distribution_normal(1000))), 1, tolerance = 0.1)
+    expect_equal(as.numeric(p_map(distribution_normal(1000, 1, 1))), 0.62, tolerance = 0.1)
+    expect_equal(as.numeric(p_map(distribution_normal(1000, 2, 1))), 0.15, tolerance = 0.1)
+    expect_equal(as.numeric(p_map(distribution_normal(1000, 3, 0.01))), 0, tolerance = 0.1)
   })
 
 
@@ -17,7 +17,7 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
         expect_equal(
           p_map(m, effects = "all")$p_MAP,
           p_map(p)$p_MAP,
-          tolerance = 0.01
+          tolerance = 0.1
         )
       })
 
@@ -28,7 +28,7 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
         expect_equal(
           p_map(m, effects = "all", component = "all")$p_MAP,
           p_map(p)$p_MAP,
-          tolerance = 0.01
+          tolerance = 0.1
         )
       })
     }

--- a/tests/testthat/test-p_significance.R
+++ b/tests/testthat/test-p_significance.R
@@ -3,10 +3,10 @@ if (require("rstanarm", quietly = TRUE)) {
     set.seed(333)
     x <- bayestestR::distribution_normal(10000, 1, 1)
     ps <- bayestestR::p_significance(x)
-    testthat::expect_equal(as.numeric(ps), 0.816, tolerance = 0.1)
-    testthat::expect_equal(nrow(p_significance(data.frame(replicate(4, rnorm(100))))), 4)
-    testthat::expect_is(ps, "p_significance")
-    testthat::expect_equal(tail(capture.output(print(ps)), 1), "ps [0.10] = 81.60%")
+    expect_equal(as.numeric(ps), 0.816, tolerance = 0.1)
+    expect_equal(nrow(p_significance(data.frame(replicate(4, rnorm(100))))), 4)
+    expect_s3_class(ps, "p_significance")
+    expect_equal(tail(capture.output(print(ps)), 1), "ps [0.10] = 81.60%")
   })
 
 
@@ -16,7 +16,7 @@ if (require("rstanarm", quietly = TRUE)) {
       m <- insight::download_model("stanreg_merMod_5")
       p <- insight::get_parameters(m, effects = "all")
 
-      testthat::expect_equal(
+      expect_equal(
         p_significance(m, effects = "all")$ps[1],
         0.99,
         tolerance = 1e-2

--- a/tests/testthat/test-point_estimate.R
+++ b/tests/testthat/test-point_estimate.R
@@ -4,7 +4,7 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
     p <- insight::get_parameters(m, effects = "all")
 
     test_that("point_estimate", {
-      testthat::expect_equal(
+      expect_equal(
         point_estimate(m, effects = "all")$Median,
         point_estimate(p)$Median,
         tolerance = 1e-3
@@ -15,7 +15,7 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
     p <- insight::get_parameters(m, effects = "all", component = "all")
 
     test_that("point_estimate", {
-      testthat::expect_equal(
+      expect_equal(
         point_estimate(m, effects = "all", component = "all")$Median,
         point_estimate(p)$Median,
         tolerance = 1e-3

--- a/tests/testthat/test-rope.R
+++ b/tests/testthat/test-rope.R
@@ -1,31 +1,31 @@
 if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
   test_that("rope", {
-    testthat::expect_equal(as.numeric(rope(distribution_normal(1000, 0, 1))), 0.0898, tolerance = 0.01)
-    testthat::expect_equal(equivalence_test(distribution_normal(1000, 0, 1))$ROPE_Equivalence, "Undecided")
-    testthat::expect_equal(length(capture.output(print(equivalence_test(distribution_normal(1000))))), 9)
-    testthat::expect_equal(length(capture.output(print(equivalence_test(distribution_normal(1000), ci = c(0.8, 0.9))))), 14)
+    expect_equal(as.numeric(rope(distribution_normal(1000, 0, 1))), 0.0898, tolerance = 0.01)
+    expect_equal(equivalence_test(distribution_normal(1000, 0, 1))$ROPE_Equivalence, "Undecided")
+    expect_equal(length(capture.output(print(equivalence_test(distribution_normal(1000))))), 9)
+    expect_equal(length(capture.output(print(equivalence_test(distribution_normal(1000), ci = c(0.8, 0.9))))), 14)
 
-    testthat::expect_equal(as.numeric(rope(distribution_normal(1000, 2, 0.01))), 0, tolerance = 0.01)
-    testthat::expect_equal(equivalence_test(distribution_normal(1000, 2, 0.01))$ROPE_Equivalence, "Rejected")
+    expect_equal(as.numeric(rope(distribution_normal(1000, 2, 0.01))), 0, tolerance = 0.01)
+    expect_equal(equivalence_test(distribution_normal(1000, 2, 0.01))$ROPE_Equivalence, "Rejected")
 
-    testthat::expect_equal(as.numeric(rope(distribution_normal(1000, 0, 0.001))), 1, tolerance = 0.01)
-    testthat::expect_equal(equivalence_test(distribution_normal(1000, 0, 0.001))$ROPE_Equivalence, "Accepted")
+    expect_equal(as.numeric(rope(distribution_normal(1000, 0, 0.001))), 1, tolerance = 0.01)
+    expect_equal(equivalence_test(distribution_normal(1000, 0, 0.001))$ROPE_Equivalence, "Accepted")
 
-    testthat::expect_equal(equivalence_test(distribution_normal(1000, 0, 0.001), ci = 1)$ROPE_Equivalence, "Accepted")
+    expect_equal(equivalence_test(distribution_normal(1000, 0, 0.001), ci = 1)$ROPE_Equivalence, "Accepted")
 
     # print(rope(rnorm(1000, mean = 0, sd = 3), ci = .5))
-    testthat::expect_equal(rope(rnorm(1000, mean = 0, sd = 3), ci = c(.1, .5, .9))$CI, c(10, 50, 90))
+    expect_equal(rope(rnorm(1000, mean = 0, sd = 3), ci = c(.1, .5, .9))$CI, c(10, 50, 90))
 
     x <- equivalence_test(distribution_normal(1000, 1, 1), ci = c(.50, .99))
-    testthat::expect_equal(x$ROPE_Percentage[2], 0.0494, tolerance = 0.01)
-    testthat::expect_equal(x$ROPE_Equivalence[2], "Undecided")
+    expect_equal(x$ROPE_Percentage[2], 0.0494, tolerance = 0.01)
+    expect_equal(x$ROPE_Equivalence[2], "Undecided")
 
-    testthat::expect_error(rope(distribution_normal(1000, 0, 1), range = c(0.0, 0.1, 0.2)))
+    expect_error(rope(distribution_normal(1000, 0, 1), range = c(0.0, 0.1, 0.2)))
 
     set.seed(333)
-    testthat::expect_is(rope(distribution_normal(1000, 0, 1)), "rope")
-    testthat::expect_error(rope(distribution_normal(1000, 0, 1), range = c("A", 0.1)))
-    testthat::expect_equal(as.numeric(rope(distribution_normal(1000, 0, 1), range = c(-0.1, 0.1))), 0.0898, tolerance = 0.01)
+    expect_s3_class(rope(distribution_normal(1000, 0, 1)), "rope")
+    expect_error(rope(distribution_normal(1000, 0, 1), range = c("A", 0.1)))
+    expect_equal(as.numeric(rope(distribution_normal(1000, 0, 1), range = c(-0.1, 0.1))), 0.0898, tolerance = 0.01)
   })
 
 
@@ -36,7 +36,7 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
       p <- insight::get_parameters(m, effects = "all")
 
       test_that("rope", {
-        testthat::expect_equal(
+        expect_equal(
           # fix range to -.1/.1, to compare to data frame method
           rope(m, range = c(-.1, .1), effects = "all")$ROPE_Percentage,
           rope(p)$ROPE_Percentage,
@@ -48,7 +48,7 @@ if (require("rstanarm", quietly = TRUE) && require("brms", quietly = TRUE)) {
       p <- insight::get_parameters(m, effects = "all", component = "all")
 
       test_that("rope", {
-        testthat::expect_equal(
+        expect_equal(
           rope(m, effects = "all", component = "all")$ROPE_Percentage,
           rope(p)$ROPE_Percentage,
           tolerance = 1e-3

--- a/tests/testthat/test-rstanarm.R
+++ b/tests/testthat/test-rstanarm.R
@@ -6,38 +6,38 @@ if (.runThisTest) {
 
       set.seed(333)
       model <- insight::download_model("stanreg_lm_1")
-      expect_equal(rope_range(model)[1], -0.602, tol = 0.1)
+      expect_equal(rope_range(model)[1], -0.602, tolerance = 0.1)
 
       model <- insight::download_model("stanreg_meanfield_lm_1")
-      expect_equal(rope_range(model)[1], -0.602, tol = 0.1)
+      expect_equal(rope_range(model)[1], -0.602, tolerance = 0.1)
 
       model <- insight::download_model("stanreg_fullrank_lm_1")
-      expect_equal(rope_range(model)[1], -0.602, tol = 0.1)
+      expect_equal(rope_range(model)[1], -0.602, tolerance = 0.1)
 
       model <- insight::download_model("stanreg_lmerMod_1")
-      expect_equal(rope_range(model)[1], -0.097, tol = 0.1)
+      expect_equal(rope_range(model)[1], -0.097, tolerance = 0.1)
 
       model <- insight::download_model("stanreg_glm_1")
-      expect_equal(rope_range(model)[1], -0.18, tol = 0.1)
+      expect_equal(rope_range(model)[1], -0.18, tolerance = 0.1)
 
       model <- insight::download_model("stanreg_merMod_1")
-      expect_equal(rope_range(model)[1], -0.18, tol = 0.1)
+      expect_equal(rope_range(model)[1], -0.18, tolerance = 0.1)
 
       model <- insight::download_model("stanreg_gamm4_1")
-      expect_equal(rope_range(model)[1], -0.043, tol = 0.1)
+      expect_equal(rope_range(model)[1], -0.043, tolerance = 0.1)
 
       model <- insight::download_model("stanreg_gam_1")
       params <- describe_posterior(model, centrality = "all", test = "all", dispersion = TRUE)
       expect_equal(c(nrow(params), ncol(params)), c(4, 22))
 
-      expect_is(hdi(model), "data.frame")
-      expect_is(ci(model), "data.frame")
-      expect_is(rope(model), "data.frame")
+      expect_s3_class(hdi(model), "data.frame")
+      expect_s3_class(ci(model), "data.frame")
+      expect_s3_class(rope(model), "data.frame")
       # expect_true("equivalence_test" %in% class(equivalence_test(model)))
-      expect_is(map_estimate(model), "data.frame")
-      expect_is(p_map(model), "data.frame")
-      expect_is(mhdior(model), "data.frame")
-      expect_is(p_direction(model), "data.frame")
+      expect_s3_class(map_estimate(model), "data.frame")
+      expect_s3_class(p_map(model), "data.frame")
+      expect_s3_class(mhdior(model), "data.frame")
+      expect_s3_class(p_direction(model), "data.frame")
 
       # expect_error(equivalence_test(model, range = c(.1, .3, .5)))
       # print(equivalence_test(model, ci = c(.1, .3, .5)))
@@ -55,8 +55,8 @@ if (.runThisTest) {
         "Parameter", "Mean", "CI", "CI_low", "CI_high", "pd", "ROPE_CI",
         "ROPE_low", "ROPE_high", "ROPE_Percentage", "Rhat", "ESS"
       ))
-      expect_equal(s[1:4, 1, drop = TRUE], out$Mean, check.attributes = FALSE, tolerance = 1e-3)
-      expect_equal(s[1:4, 8, drop = TRUE], out$Rhat, check.attributes = FALSE, tolerance = 1e-1)
+      expect_equal(s[1:4, 1, drop = TRUE], out$Mean, ignore.attr = TRUE, tolerance = 1e-3)
+      expect_equal(s[1:4, 8, drop = TRUE], out$Rhat, ignore.attr = TRUE, tolerance = 1e-1)
     })
 
     test_that("rstanarm", {
@@ -72,8 +72,8 @@ if (.runThisTest) {
         "pd", "ROPE_CI", "ROPE_low", "ROPE_high", "ROPE_Percentage",
         "Rhat", "ESS"
       ))
-      expect_equal(s[1:8, 1, drop = TRUE], out$Mean, check.attributes = FALSE, tolerance = 1e-3)
-      expect_equal(s[1:8, 8, drop = TRUE], out$Rhat, check.attributes = FALSE, tolerance = 1e-1)
+      expect_equal(s[1:8, 1, drop = TRUE], out$Mean, ignore.attr = TRUE, tolerance = 1e-3)
+      expect_equal(s[1:8, 8, drop = TRUE], out$Rhat, ignore.attr = TRUE, tolerance = 1e-1)
     })
 
     test_that("rstanarm", {
@@ -88,8 +88,8 @@ if (.runThisTest) {
         "Parameter", "Response", "Mean", "CI", "CI_low", "CI_high",
         "Rhat", "ESS"
       ))
-      expect_equal(s[c(1:2, 5:7), 1, drop = TRUE], out$Mean, check.attributes = FALSE, tolerance = 1e-3)
-      expect_equal(s[c(1:2, 5:7), 10, drop = TRUE], out$Rhat, check.attributes = FALSE, tolerance = 1e-1)
+      expect_equal(s[c(1:2, 5:7), 1, drop = TRUE], out$Mean, ignore.attr = TRUE, tolerance = 1e-3)
+      expect_equal(s[c(1:2, 5:7), 10, drop = TRUE], out$Rhat, ignore.attr = TRUE, tolerance = 1e-1)
     })
 
 

--- a/tests/testthat/test-rstanarm.R
+++ b/tests/testthat/test-rstanarm.R
@@ -55,8 +55,8 @@ if (.runThisTest) {
         "Parameter", "Mean", "CI", "CI_low", "CI_high", "pd", "ROPE_CI",
         "ROPE_low", "ROPE_high", "ROPE_Percentage", "Rhat", "ESS"
       ))
-      expect_equal(s[1:4, 1, drop = TRUE], out$Mean, ignore.attr = TRUE, tolerance = 1e-3)
-      expect_equal(s[1:4, 8, drop = TRUE], out$Rhat, ignore.attr = TRUE, tolerance = 1e-1)
+      expect_equal(as.vector(s[1:4, 1, drop = TRUE]), out$Mean, tolerance = 1e-3)
+      expect_equal(as.vector(s[1:4, 8, drop = TRUE]), out$Rhat, tolerance = 1e-1)
     })
 
     test_that("rstanarm", {
@@ -72,8 +72,8 @@ if (.runThisTest) {
         "pd", "ROPE_CI", "ROPE_low", "ROPE_high", "ROPE_Percentage",
         "Rhat", "ESS"
       ))
-      expect_equal(s[1:8, 1, drop = TRUE], out$Mean, ignore.attr = TRUE, tolerance = 1e-3)
-      expect_equal(s[1:8, 8, drop = TRUE], out$Rhat, ignore.attr = TRUE, tolerance = 1e-1)
+      expect_equal(as.vector(s[1:8, 1, drop = TRUE]), out$Mean, tolerance = 1e-3)
+      expect_equal(as.vector(s[1:8, 8, drop = TRUE]), out$Rhat, tolerance = 1e-1)
     })
 
     test_that("rstanarm", {
@@ -88,8 +88,8 @@ if (.runThisTest) {
         "Parameter", "Response", "Mean", "CI", "CI_low", "CI_high",
         "Rhat", "ESS"
       ))
-      expect_equal(s[c(1:2, 5:7), 1, drop = TRUE], out$Mean, ignore.attr = TRUE, tolerance = 1e-3)
-      expect_equal(s[c(1:2, 5:7), 10, drop = TRUE], out$Rhat, ignore.attr = TRUE, tolerance = 1e-1)
+      expect_equal(as.vector(s[c(1:2, 5:7), 1, drop = TRUE]), out$Mean, tolerance = 1e-3)
+      expect_equal(as.vector(s[c(1:2, 5:7), 10, drop = TRUE]), out$Rhat, tolerance = 1e-1)
     })
 
 

--- a/tests/testthat/test-si.R
+++ b/tests/testthat/test-si.R
@@ -6,9 +6,9 @@ if (require("rstanarm") && require("bayestestR") && require("testthat")) {
     posterior <- distribution_normal(1000, mean = .5, sd = .3)
 
     res <- si(posterior, prior)
-    expect_equal(res$CI_low, 0.039, tolerance = 0.02)
-    expect_equal(res$CI_high, 1.053, tolerance = 0.02)
-    expect_is(res, c("bayestestR_si"))
+    expect_equal(res$CI_low, 0.03999124, tolerance = 0.02)
+    expect_equal(res$CI_high, 1.053103, tolerance = 0.02)
+    expect_s3_class(res, c("bayestestR_si"))
 
     res <- si(posterior, prior, BF = 3)
     expect_equal(res$CI_low, 0.333, tolerance = 0.02)
@@ -37,7 +37,7 @@ if (require("rstanarm") && require("bayestestR") && require("testthat")) {
     set.seed(333)
     res2 <- si(stan_model, verbose = FALSE)
 
-    expect_is(res1, c("bayestestR_si"))
+    expect_s3_class(res1, c("bayestestR_si"))
     expect_equal(res1, res2)
   })
 }

--- a/tests/testthat/test-si.R
+++ b/tests/testthat/test-si.R
@@ -1,5 +1,4 @@
 if (require("rstanarm") && require("bayestestR") && require("testthat")) {
-
   test_that("si.numeric", {
     set.seed(333)
     prior <- distribution_normal(1000, mean = 0, sd = 1)

--- a/tests/testthat/test-simulate_data.R
+++ b/tests/testthat/test-simulate_data.R
@@ -1,12 +1,12 @@
 test_that("simulate_correlation", {
   set.seed(333)
   data <- simulate_correlation(r = 0.5, n = 50)
-  testthat::expect_equal(as.numeric(cor.test(data$V1, data$V2)$estimate), 0.5, tol = 0.001)
+  expect_equal(as.numeric(cor.test(data$V1, data$V2)$estimate), 0.5, tolerance = 0.001)
 
   data <- simulate_correlation(r = 0.5, n = 50, mean = c(0, 1), sd = c(0.7, 1.7))
-  testthat::expect_equal(as.numeric(cor.test(data$V1, data$V2)$estimate), 0.5, tol = 0.001)
-  testthat::expect_equal(c(mean(data$V1), sd(data$V1)), c(0, 0.7), tol = 0.001)
-  testthat::expect_equal(c(mean(data$V2), sd(data$V2)), c(1, 1.7), tol = 0.001)
+  expect_equal(as.numeric(cor.test(data$V1, data$V2)$estimate), 0.5, tolerance = 0.001)
+  expect_equal(c(mean(data$V1), sd(data$V1)), c(0, 0.7), tolerance = 0.001)
+  expect_equal(c(mean(data$V2), sd(data$V2)), c(1, 1.7), tolerance = 0.001)
 
   cor_matrix <- matrix(c(
     1.0, 0.2, 0.4,
@@ -18,5 +18,5 @@ test_that("simulate_correlation", {
 
   data <- simulate_correlation(r = cor_matrix)
 
-  testthat::expect_equal(matrix(cor(data), nrow = 3), cor_matrix, tol = 0.001)
+  expect_equal(matrix(cor(data), nrow = 3), cor_matrix, tolerance = 0.001)
 })

--- a/tests/testthat/test-weighted_posteriors.R
+++ b/tests/testthat/test-weighted_posteriors.R
@@ -85,9 +85,9 @@ if (.runThisTest) {
       res_brms1 <- eti(res_brms)
 
       expect_equal(res_BT1$Parameter, res_brms1$Parameter)
-      testthat::expect_equal(res_BT1$CI, res_brms1$CI)
-      testthat::expect_equal(res_BT1$CI_low, res_brms1$CI_low)
-      testthat::expect_equal(res_BT1$CI_high, res_brms1$CI_high)
+      expect_equal(res_BT1$CI, res_brms1$CI)
+      expect_equal(res_BT1$CI_low, res_brms1$CI_low)
+      expect_equal(res_BT1$CI_high, res_brms1$CI_high)
 
       # plot(res_brms1)
       # plot(res_BT1)

--- a/tests/testthat/test-weighted_posteriors.R
+++ b/tests/testthat/test-weighted_posteriors.R
@@ -35,8 +35,8 @@ if (require("BayesFactor", quietly = TRUE)) {
     expect_equal(attr(res, "weights")$weights, c(1032, 805, 1388, 775))
 
     wHDI <- hdi(res[c("x1", "x2")], ci = 0.9)
-    expect_equal(wHDI$CI_low, c(-0.519, -0.640), tolerance = 1e-3)
-    expect_equal(wHDI$CI_high, c(0.150, 0.059), tolerance = 1e-3)
+    expect_equal(wHDI$CI_low, c(-0.519, -0.640), tolerance = 0.01)
+    expect_equal(wHDI$CI_high, c(0.150, 0.059), tolerance = 0.01)
   })
 
   test_that("weighted_posteriors for nonlinear BayesFactor", {

--- a/tests/testthat/test-weighted_posteriors.R
+++ b/tests/testthat/test-weighted_posteriors.R
@@ -1,6 +1,6 @@
 if (require("BayesFactor", quietly = TRUE)) {
   test_that("weighted_posteriors for BayesFactor", {
-    testthat::skip_on_cran()
+    skip_on_cran()
     set.seed(123)
     # compute Bayes Factor for 31 different regression models
     null_den <- regressionBF(mpg ~ cyl + disp + hp + drat + wt,
@@ -8,8 +8,8 @@ if (require("BayesFactor", quietly = TRUE)) {
     )
     wBF <- weighted_posteriors(null_den)
 
-    testthat::expect_is(wBF, "data.frame")
-    testthat::expect_equal(
+    expect_s3_class(wBF, "data.frame")
+    expect_equal(
       attr(wBF, "weights")$weights,
       c(
         0, 13, 9, 0, 0, 55, 11, 4, 4, 1246, 6, 2, 38, 4, 946, 12, 3,
@@ -21,8 +21,8 @@ if (require("BayesFactor", quietly = TRUE)) {
   test_that("weighted_posteriors for BayesFactor (intercept)", {
     set.seed(123)
     # fails for win old-release
-    testthat::skip_on_cran()
-    testthat::skip_on_ci()
+    skip_on_cran()
+    skip_on_ci()
 
     dat <- data.frame(
       x1 = rnorm(10),
@@ -32,11 +32,11 @@ if (require("BayesFactor", quietly = TRUE)) {
     BFmods <- regressionBF(y ~ x1 + x2, data = dat, progress = FALSE)
 
     res <- weighted_posteriors(BFmods)
-    testthat::expect_equal(attr(res, "weights")$weights, c(1032, 805, 1388, 775))
+    expect_equal(attr(res, "weights")$weights, c(1032, 805, 1388, 775))
 
     wHDI <- hdi(res[c("x1", "x2")], ci = 0.9)
-    testthat::expect_equal(wHDI$CI_low, c(-0.519, -0.640), tol = 1e-3)
-    testthat::expect_equal(wHDI$CI_high, c(0.150, 0.059), tol = 1e-3)
+    expect_equal(wHDI$CI_low, c(-0.519, -0.640), tolerance = 1e-3)
+    expect_equal(wHDI$CI_high, c(0.150, 0.059), tolerance = 1e-3)
   })
 
   test_that("weighted_posteriors for nonlinear BayesFactor", {
@@ -52,7 +52,7 @@ if (require("BayesFactor", quietly = TRUE)) {
 
     res <- weighted_posteriors(BFS)
 
-    testthat::expect_equal(attributes(res)$weights$weights, c(113, 3876, 11))
+    expect_equal(attributes(res)$weights$weights, c(113, 3876, 11))
   })
 }
 
@@ -60,7 +60,7 @@ if (require("BayesFactor", quietly = TRUE)) {
 if (.runThisTest) {
   if (require("brms", quietly = TRUE)) {
     test_that("weighted_posteriors vs posterior_average", {
-      testthat::skip_on_cran()
+      skip_on_cran()
 
       fit1 <- brm(rating ~ treat + period + carry,
         data = inhaler,
@@ -84,7 +84,7 @@ if (.runThisTest) {
       res_BT1 <- eti(res_BT)
       res_brms1 <- eti(res_brms)
 
-      testthat::expect_equal(res_BT1$Parameter, res_brms1$Parameter)
+      expect_equal(res_BT1$Parameter, res_brms1$Parameter)
       testthat::expect_equal(res_BT1$CI, res_brms1$CI)
       testthat::expect_equal(res_BT1$CI_low, res_brms1$CI_low)
       testthat::expect_equal(res_BT1$CI_high, res_brms1$CI_high)


### PR DESCRIPTION
Expect a few tests to fail due to changes in how `testthat` now checks for values. 

I have changed as many tests as I can, but some I have not because I am not sure if it is a good idea for me to be changing them without knowing the full context in which they were written. 