### PR TITLE
Update p_direction.R

### DIFF
--- a/R/describe_posterior.R
+++ b/R/describe_posterior.R
@@ -718,7 +718,11 @@ describe_posterior.bamlss <- function(posteriors, centrality = "median", dispers
 
 #' @export
 describe_posterior.get_predicted <- function(posteriors, centrality = "median", dispersion = FALSE, ci = 0.95, ci_method = "hdi", test = NULL, ...) {
-  describe_posterior(as.data.frame(t(posteriors)), centrality = centrality, dispersion = dispersion, ci = ci, ci_method = ci_method, test = test, ...)
+  if("iterations" %in% names(attributes(posteriors))) {
+    describe_posterior(as.data.frame(t(attributes(posteriors)$iterations)), centrality = centrality, dispersion = dispersion, ci = ci, ci_method = ci_method, test = test, ...)
+  } else{
+    stop("No iterations present in the output.")
+  }
 }
 # Helpers -----------------------------------------------------------------
 

--- a/R/eti.R
+++ b/R/eti.R
@@ -211,7 +211,11 @@ eti.BFBayesFactor <- function(x, ci = .89, verbose = TRUE, ...) {
 
 #' @export
 eti.get_predicted <- function(x, ...) {
-  out <- eti(as.data.frame(t(x)), ...)
+  if("iterations" %in% names(attributes(x))) {
+    out <- hdi(as.data.frame(t(attributes(x)$iterations)), ...)
+  } else{
+    stop("No iterations present in the output.")
+  }
   attr(out, "object_name") <- .safe_deparse(substitute(x))
   out
 }

--- a/R/hdi.R
+++ b/R/hdi.R
@@ -264,7 +264,11 @@ hdi.BFBayesFactor <- function(x, ci = .89, verbose = TRUE, ...) {
 
 #' @export
 hdi.get_predicted <- function(x, ...) {
-  out <- hdi(as.data.frame(t(x)), ...)
+  if("iterations" %in% names(attributes(x))) {
+    out <- hdi(as.data.frame(t(attributes(x)$iterations)), ...)
+  } else{
+    stop("No iterations present in the output.")
+  }
   attr(out, "object_name") <- .safe_deparse(substitute(x))
   out
 }

--- a/R/map_estimate.R
+++ b/R/map_estimate.R
@@ -144,7 +144,11 @@ map_estimate.emm_list <- map_estimate.emmGrid
 
 #' @export
 map_estimate.get_predicted <- function(x, ...) {
-  map_estimate(as.data.frame(t(x)), ...)
+  if("iterations" %in% names(attributes(x))) {
+    map_estimate(as.data.frame(t(attributes(x)$iterations)), ...)
+  } else{
+    stop("No iterations present in the output.")
+  }
 }
 
 # Methods -----------------------------------------------------------------

--- a/R/p_direction.R
+++ b/R/p_direction.R
@@ -317,7 +317,11 @@ p_direction.BFBayesFactor <- function(x, method = "direct", null = 0, ...) {
 
 #' @export
 p_direction.get_predicted <- function(x, ...) {
-  out <- p_direction(as.data.frame(t(x)), ...)
+  if("iterations" %in% names(attributes(x))) {
+    out <- p_direction(as.data.frame(t(attributes(x)$iterations)), ...)
+  } else{
+    stop("No iterations present in the output.")
+  }
   attr(out, "object_name") <- .safe_deparse(substitute(x))
   out
 }

--- a/R/p_direction.R
+++ b/R/p_direction.R
@@ -118,14 +118,23 @@ pd <- p_direction
 #' @importFrom stats density
 #' @rdname p_direction
 #' @export
-p_direction.numeric <- function(x, method = "direct", ...) {
+p_direction.numeric <- function(x, method = "direct", null = 0, ...) {
   if (method == "direct") {
-    pdir <- max(
-      c(
-        length(x[x > 0]) / length(x), # pd positive
-        length(x[x < 0]) / length(x) # pd negative
+    if(null == 0) {
+      pdir <- max(
+        c(
+          length(x[x > 0]) / length(x), # pd positive
+          length(x[x < 0]) / length(x) # pd negative
+        )
       )
-    )
+    } else if (null == 1) {
+      pdir <- max(
+        c(
+          length(x[x > 1]) / length(x), # pd positive
+          length(x[x < 1]) / length(x) # pd negative
+        )
+      )
+    } else {print('Value for the null argument must be 0 or 1')}
   } else {
     dens <- estimate_density(x, method = method, precision = 2^10, extend = TRUE, ...)
     if (length(x[x > 0]) > length(x[x < 0])) {
@@ -136,12 +145,12 @@ p_direction.numeric <- function(x, method = "direct", ...) {
     pdir <- area_under_curve(dens$x, dens$y, method = "spline")
     if (pdir >= 1) pdir <- 1 # Enforce bounds
   }
-
+  
   attr(pdir, "method") <- method
   attr(pdir, "data") <- x
-
+  
   class(pdir) <- unique(c("p_direction", "see_p_direction", class(pdir)))
-
+  
   pdir
 }
 

--- a/R/p_direction.R
+++ b/R/p_direction.R
@@ -292,7 +292,7 @@ p_direction.stanfit <- p_direction.stanreg
 
 #' @rdname p_direction
 #' @export
-p_direction.brmsfit <- function(x, effects = c("fixed", "random", "all"), component = c("conditional", "zi", "zero_inflated", "all"), parameters = NULL, method = "direct", null = null, ...) {
+p_direction.brmsfit <- function(x, effects = c("fixed", "random", "all"), component = c("conditional", "zi", "zero_inflated", "all"), parameters = NULL, method = "direct", null = 0, ...) {
   effects <- match.arg(effects)
   component <- match.arg(component)
 

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -299,5 +299,9 @@ point_estimate.matrix <- function(x, ...) {
 
 #' @export
 point_estimate.get_predicted <- function(x, ...) {
-  point_estimate(as.data.frame(t(x)), ...)
+  if("iterations" %in% names(attributes(x))) {
+    point_estimate(as.data.frame(t(attributes(x)$iterations)), ...)
+  } else{
+    as.numeric(x)
+  }
 }

--- a/R/reshape_iterations.R
+++ b/R/reshape_iterations.R
@@ -18,6 +18,11 @@
 #' @export
 reshape_iterations <- function(x, prefix = c("draw", "iter", "iteration", "sim")) {
 
+  # Accomodate output from get_predicted
+  if(inherits(x, "get_predicted") && "iterations" %in% names(attributes(x))) {
+    x <- as.data.frame(x)
+  }
+
   # Find columns' name
   prefix <- prefix[min(which(sapply(tolower(prefix), function(prefix) sum(grepl(prefix, tolower(names(x)))) > 1)))]
 

--- a/bayestestR.Rproj
+++ b/bayestestR.Rproj
@@ -16,7 +16,7 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageInstallArgs: --no-multiarch --with-keep.source
+PackageInstallArgs: --with-keep.source
 PackageBuildArgs: --compact-vignettes=both
 PackageCheckArgs: --as-cran --run-donttest
 PackageRoxygenize: rd,collate,namespace

--- a/man/estimate_density.Rd
+++ b/man/estimate_density.Rd
@@ -61,14 +61,16 @@ set.seed(1)
 x <- rnorm(250, mean = 1)
 
 # Basic usage
-density_kernel <- estimate_density(x)  # default method is "kernel"
+density_kernel <- estimate_density(x) # default method is "kernel"
 
 hist(x, prob = TRUE)
 lines(density_kernel$x, density_kernel$y, col = "black", lwd = 2)
 lines(density_kernel$x, density_kernel$CI_low, col = "gray", lty = 2)
 lines(density_kernel$x, density_kernel$CI_high, col = "gray", lty = 2)
-legend("topright", legend = c("Estimate", "95\% CI"),
-       col = c("black", "gray"), lwd = 2, lty = c(1, 2))
+legend("topright",
+  legend = c("Estimate", "95\% CI"),
+  col = c("black", "gray"), lwd = 2, lty = c(1, 2)
+)
 
 # Other Methods
 density_logspline <- estimate_density(x, method = "logspline")
@@ -94,8 +96,8 @@ df <- data.frame(replicate(4, rnorm(100)))
 head(estimate_density(df))
 
 # Grouped data
-estimate_density(iris, group_by="Species")
-estimate_density(iris$Petal.Width, group_by=iris$Species)
+estimate_density(iris, group_by = "Species")
+estimate_density(iris$Petal.Width, group_by = iris$Species)
 \dontrun{
 # rstanarm models
 # -----------------------------------------------

--- a/man/p_direction.Rd
+++ b/man/p_direction.Rd
@@ -16,13 +16,13 @@ p_direction(x, ...)
 
 pd(x, ...)
 
-\method{p_direction}{numeric}(x, method = "direct", ...)
+\method{p_direction}{numeric}(x, method = "direct", null = 0, ...)
 
-\method{p_direction}{data.frame}(x, method = "direct", ...)
+\method{p_direction}{data.frame}(x, method = "direct", null = 0, ...)
 
-\method{p_direction}{MCMCglmm}(x, method = "direct", ...)
+\method{p_direction}{MCMCglmm}(x, method = "direct", null = 0, ...)
 
-\method{p_direction}{emmGrid}(x, method = "direct", ...)
+\method{p_direction}{emmGrid}(x, method = "direct", null = 0, ...)
 
 \method{p_direction}{stanreg}(
   x,
@@ -31,6 +31,7 @@ pd(x, ...)
     "distributional", "auxiliary"),
   parameters = NULL,
   method = "direct",
+  null = 0,
   ...
 )
 
@@ -40,10 +41,11 @@ pd(x, ...)
   component = c("conditional", "zi", "zero_inflated", "all"),
   parameters = NULL,
   method = "direct",
+  null = null,
   ...
 )
 
-\method{p_direction}{BFBayesFactor}(x, method = "direct", ...)
+\method{p_direction}{BFBayesFactor}(x, method = "direct", null = 0, ...)
 }
 \arguments{
 \item{x}{Vector representing a posterior distribution. Can also be a Bayesian model (\code{stanreg}, \code{brmsfit} or \code{BayesFactor}).}
@@ -51,6 +53,8 @@ pd(x, ...)
 \item{...}{Currently not used.}
 
 \item{method}{Can be \code{"direct"} or one of methods of \link[=estimate_density]{density estimation}, such as \code{"kernel"}, \code{"logspline"} or \code{"KernSmooth"}. If \code{"direct"} (default), the computation is based on the raw ratio of samples superior and inferior to 0. Else, the result is based on the \link[=auc]{Area under the Curve (AUC)} of the estimated \link[=estimate_density]{density} function.}
+
+\item{null}{The value considered as a "null" effect. Traditionally 0, but could also be 1 in the case of ratios.}
 
 \item{effects}{Should results for fixed effects, random effects or both be returned?
 Only applies to mixed models. May be abbreviated.}

--- a/man/p_direction.Rd
+++ b/man/p_direction.Rd
@@ -41,7 +41,7 @@ pd(x, ...)
   component = c("conditional", "zi", "zero_inflated", "all"),
   parameters = NULL,
   method = "direct",
-  null = null,
+  null = 0,
   ...
 )
 


### PR DESCRIPTION
Following on from conversation in issue #374, added a `null` argument for the direct method only (not for density estimation methods) as a proof of concept.

# Description

This PR aims at adding a `null` argument for p_direction as in some instances other values besides 0 are meaningful (e.g., 1 for ratios)

# Proposed Changes

I changed the `p_direction` function so that a `null` argument can be input and only values of 0 (default) or 1 can be input with an error message being printed if values are not 0 or 1.