### PR TITLE
estimate_density: improvement of `at` argument (old `group_by`)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,11 @@
 
 ## Breaking
 
-* `Bayesfactor_models()` for frequentist models now relies on the updated `insight::get_loglikelihood()`. This might change some results for REML based models. See documentation. 
+* `Bayesfactor_models()` for frequentist models now relies on the updated `insight::get_loglikelihood()`. This might change some results for REML based models. See documentation.
 
 ## Breaking
+
+* `estimate_density()` argument `group_by` is renamed `at`.
 
 * All `distribution_*(random = FALSE)` functions now rely on `ppoints()`, which will result in slightly diffrent results, especially with small `n`s.
 
@@ -31,13 +33,13 @@
 
 ## Breaking
 
-* All Bayes factors are now returned as `log(BF)` (column name `log_BF`). 
+* All Bayes factors are now returned as `log(BF)` (column name `log_BF`).
   Printing is unaffected. To retrieve the raw BFs, you can run `exp(result$log_BF)`.
 
 ## New functions
 
 * `bci()` (and its alias `bcai()`) to compute bias-corrected and accelerated
-  bootstrap intervals. Along with this new function, `ci()` and 
+  bootstrap intervals. Along with this new function, `ci()` and
   `describe_posterior()` gain a new `ci_method` type, `"bci"`.
 
 ## Changes

--- a/R/estimate_density.R
+++ b/R/estimate_density.R
@@ -129,7 +129,7 @@ estimate_density <- function(x, method = "kernel", precision = 2^10, extend = FA
 
 
 #' @export
-estimate_density.numeric <- function(x, method = "kernel", precision = 2^10, extend = FALSE, extend_scale = 0.1, bw = "SJ", ci = NULL, at = NULL, ...) {
+estimate_density.numeric <- function(x, method = "kernel", precision = 2^10, extend = FALSE, extend_scale = 0.1, bw = "SJ", ci = NULL, at = NULL, group_by = NULL, ...) {
 
   # Sanity
   if(!is.null(group_by)) {

--- a/man/estimate_density.Rd
+++ b/man/estimate_density.Rd
@@ -25,6 +25,7 @@ estimate_density(
   bw = "SJ",
   ci = NULL,
   select = NULL,
+  at = NULL,
   group_by = NULL,
   ...
 )
@@ -50,7 +51,9 @@ vectors. Can also be a Bayesian model (\code{stanreg}, \code{brmsfit},
 
 \item{select}{Character vector of column names. If NULL (the default), all numeric variables will be selected.}
 
-\item{group_by}{Optional character vector. If not \code{NULL} and \code{x} is a data frame, density estimation is performed for each group (subset) indicated by \code{group_by}.}
+\item{at}{Optional character vector. If not \code{NULL} and input is a data frame, density estimation is performed for each group (subsets) indicated by \code{at}. See examples.}
+
+\item{group_by}{Deprecated in favourt of \code{at}.}
 }
 \description{
 This function is a wrapper over different methods of density estimation. By default, it uses the base R \code{density} with by default uses a different smoothing bandwidth (\code{"SJ"}) from the legacy default implemented the base R \code{density} function (\code{"nrd0"}). However, Deng \& Wickham suggest that \code{method = "KernSmooth"} is the fastest and the most accurate.
@@ -100,8 +103,8 @@ head(estimate_density(iris))
 head(estimate_density(iris, select = "Sepal.Width"))
 
 # Grouped data
-head(estimate_density(iris, group_by = "Species"))
-head(estimate_density(iris$Petal.Width, group_by = iris$Species))
+head(estimate_density(iris, at = "Species"))
+head(estimate_density(iris$Petal.Width, at = iris$Species))
 \dontrun{
 # rstanarm models
 # -----------------------------------------------

--- a/tests/testthat/test-estimate_density.R
+++ b/tests/testthat/test-estimate_density.R
@@ -12,5 +12,23 @@ if (require("logspline") && require("KernSmooth") && require("mclust")) {
     expect_equal(mean(density_kernel$y - density_logspline$y), 0, tolerance = 0.1)
     expect_equal(mean(density_kernel$y - density_KernSmooth$y), 0, tolerance = 0.1)
     expect_equal(mean(density_kernel$y - density_mixture$y), 0, tolerance = 0.1)
+
+    x <- iris
+    x$Fac <- rep(c("A", "B"), length.out = 150)
+
+    rez <- estimate_density(x, select = "Sepal.Length")
+    expect_equal(dim(rez), c(1024, 3))
+
+    rez <- estimate_density(x, select = c("Sepal.Length", "Petal.Length"))
+    expect_equal(dim(rez), c(2048, 3))
+
+    rez <- estimate_density(x, select = "Sepal.Length", at = "Species")
+    expect_equal(dim(rez), c(1024 * 3, 4))
+
+    rez <- estimate_density(x, select = c("Sepal.Length", "Petal.Length"), at = "Species")
+    expect_equal(dim(rez), c(2048 * 3, 4))
+
+    rez <- estimate_density(x, select = "Sepal.Length", at = c("Species", "Fac"), method = "KernSmooth")
+    expect_equal(dim(rez), c(1024 * 3 * 2, 5))
   })
 }


### PR DESCRIPTION
Renamed and improved the `group_by` arg so that we can easily do things like this:

``` r
library(ggplot2)

x <- iris
x$Fac <- rep(c("A", "B"), length.out = 150)

rez <- bayestestR::estimate_density(x, 
                                    select = c("Sepal.Length", "Petal.Width"), 
                                    at = c("Species", "Fac"), 
                                    method = "KernSmooth")
#> Loading required namespace: KernSmooth

ggplot(rez, aes(x = x, y = y, color = Parameter)) +
  geom_line() +
  facet_grid(Species ~ Fac)
```

![](https://i.imgur.com/ReR5QL2.png)

<sup>Created on 2022-03-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
