### PR TITLE
Fix Redundant Computation of Marginal Likelihood for brmsfit Objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bayestestR
 Title: Understand and Describe Bayesian Models and Posterior Distributions
-Version: 0.13.0.1
+Version: 0.13.0.2
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",
@@ -122,4 +122,4 @@ Config/Needs/website:
     rstudio/bslib,
     r-lib/pkgdown,
     easystats/easystatstemplate
-Remotes: easystats/insight
+Remotes: easystats/insight@revise_get_data

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Improved speed performance when functions are called using `do.call()`.
 
+* Improved speed performance to `bayesfactor_models()` for `brmsfit` objects
+  that already included a `marglik` element in the model object.
+
 # bayestestR 0.13.0
 
 ## Breaking

--- a/R/bayesfactor_models.R
+++ b/R/bayesfactor_models.R
@@ -52,8 +52,6 @@
 #'   random effects) and their `log(BF)`s  (Use `as.numeric()` to extract the
 #'   non-log Bayes factors; see examples), that prints nicely.
 #'
-#' @importFrom stats median
-#'
 #' @examples
 #' # With lm objects:
 #' # ----------------
@@ -309,7 +307,7 @@ bayesfactor_models.default <- function(..., denominator = 1, verbose = TRUE) {
   check_brmsfit <- sapply(mods, class)
 
   # Add a check here for brmsfit object to avoid unnecessary computation of the ML
-  if (all(grepl("brmsfit", check_brmsfit))) {
+  if (all(check_brmsfit == "brmsfit")) {
     mML <- .get_brmsfit_mML(mods, verbose)
   } else {
     # Get BF
@@ -623,7 +621,7 @@ as.matrix.bayesfactor_models <- function(x, ...) {
 
     # If marginal likelihood exists, use the stored criteria
     if (!is.na(criteria_pos)) {
-      marglik <- median(x$criteria$marglik$logml)
+      marglik <- stats::median(x$criteria$marglik$logml)
     } else {
       # Get marginal likelihood
       if (verbose) {

--- a/tests/testthat/test-bayesfactor_models.R
+++ b/tests/testthat/test-bayesfactor_models.R
@@ -67,7 +67,7 @@ if (requiet("bayestestR") && requiet("testthat") && requiet("lme4")) {
 
 
   # bayesfactor_models STAN ---------------------------------------------
-  if (requiet("rstanarm") && requiet("bridgesampling")) {
+  if (requiet("rstanarm") && requiet("bridgesampling") && requiet("brms")) {
     test_that("bayesfactor_models STAN", {
       skip_on_cran()
       set.seed(333)
@@ -99,6 +99,43 @@ if (requiet("bayestestR") && requiet("testthat") && requiet("lme4")) {
       expect_equal(length(stan_models$log_BF), 2)
       expect_equal(stan_models$log_BF[2], log(bridge_BF$bf), tolerance = 0.1)
     })
+
+    # Checks for brms models
+    set.seed(333)
+    suppressWarnings(stan_brms_model_0 <- brms::brm(
+      Sepal.Length ~ 1,
+      data = iris,
+      iter = 500,
+      refresh = 0,
+      save_pars = brms::save_pars(all = TRUE)
+    ))
+
+    stan_brms_model_0 <- brms::add_criterion(
+      stan_brms_model_0,
+      criterion = "marglik",
+      repetitions = 5,
+      silent = TRUE
+    )
+
+    stan_brms_model_1 <- brms::brm(
+      Sepal.Length ~ Petal.Length,
+      data = iris,
+      iter = 500,
+      refresh = 0,
+      save_pars = brms::save_pars(all = TRUE)
+    )
+
+    stan_brms_model_1 <- brms::add_criterion(
+      stan_brms_model_1,
+      criterion = "marglik",
+      repetitions = 5,
+      silent = TRUE
+    )
+
+    set.seed(333)
+    expect_warning(stan_brms_models <- bayesfactor_models(stan_brms_model_0, stan_brms_model_1))
+    expect_s3_class(stan_brms_models, "bayesfactor_models")
+    expect_equal(length(stan_brms_models$log_BF), 2)
   }
 
 

--- a/tests/testthat/test-bayesfactor_models.R
+++ b/tests/testthat/test-bayesfactor_models.R
@@ -1,3 +1,4 @@
+# library(testthat)
 if (requiet("bayestestR") && requiet("testthat") && requiet("lme4")) {
   # bayesfactor_models BIC --------------------------------------------------
   test_that("bayesfactor_models BIC", {
@@ -100,42 +101,49 @@ if (requiet("bayestestR") && requiet("testthat") && requiet("lme4")) {
       expect_equal(stan_models$log_BF[2], log(bridge_BF$bf), tolerance = 0.1)
     })
 
-    # Checks for brms models
-    set.seed(333)
-    suppressWarnings(stan_brms_model_0 <- brms::brm(
-      Sepal.Length ~ 1,
-      data = iris,
-      iter = 500,
-      refresh = 0,
-      save_pars = brms::save_pars(all = TRUE)
-    ))
+    test_that("bayesfactor_models BRMS", {
+      # Checks for brms models
+      skip_on_cran()
+      skip_on_ci()
 
-    stan_brms_model_0 <- brms::add_criterion(
-      stan_brms_model_0,
-      criterion = "marglik",
-      repetitions = 5,
-      silent = TRUE
-    )
+      set.seed(333)
+      stan_brms_model_0 <- brms::brm(
+        Sepal.Length ~ 1,
+        data = iris,
+        iter = 500,
+        refresh = 0,
+        save_pars = brms::save_pars(all = TRUE)
+      )
 
-    stan_brms_model_1 <- brms::brm(
-      Sepal.Length ~ Petal.Length,
-      data = iris,
-      iter = 500,
-      refresh = 0,
-      save_pars = brms::save_pars(all = TRUE)
-    )
+      stan_brms_model_1 <- brms::brm(
+        Sepal.Length ~ Petal.Length,
+        data = iris,
+        iter = 500,
+        refresh = 0,
+        save_pars = brms::save_pars(all = TRUE)
+      )
 
-    stan_brms_model_1 <- brms::add_criterion(
-      stan_brms_model_1,
-      criterion = "marglik",
-      repetitions = 5,
-      silent = TRUE
-    )
+      set.seed(444)
+      expect_message(bfm <- bayesfactor_models(stan_brms_model_0, stan_brms_model_1), regexp = "marginal")
 
-    set.seed(333)
-    expect_warning(stan_brms_models <- bayesfactor_models(stan_brms_model_0, stan_brms_model_1))
-    expect_s3_class(stan_brms_models, "bayesfactor_models")
-    expect_equal(length(stan_brms_models$log_BF), 2)
+      set.seed(444)
+      stan_brms_model_0wc <- brms::add_criterion(
+        stan_brms_model_0,
+        criterion = "marglik",
+        repetitions = 5,
+        silent = TRUE
+      )
+
+      stan_brms_model_1wc <- brms::add_criterion(
+        stan_brms_model_1,
+        criterion = "marglik",
+        repetitions = 5,
+        silent = TRUE
+      )
+
+      expect_message(bfmwc <- bayesfactor_models(stan_brms_model_0wc, stan_brms_model_1wc), regexp = NA)
+      expect_equal(bfmwc$log_BF, bfm$log_BF, tolerance = 0.01)
+    })
   }
 
 


### PR DESCRIPTION
# Description

This PR adds a helper function to `bayesfactor_models.R` to check if `brmsfit` objects passed to `bayesfactor_*` functions already include a `marglik` element in the model object and avoids redundant calls to `bridgesampling::bridge_sampler` if the criteria already exists since this can be computationally expensive.

# Proposed Changes

- [x]  Add a helper function `.get_brmsfit_mML` to `bayesfactor_models.R`
- [x]  Modify `.bayesfactor_models_stan_REG` to check for `marglik` in `brmsfit` objects before calling `bridgesampling::bridge_sampler`
- [x]  Run unit tests to verify the changes didn't break anything else in the package
