### PR TITLE
Small bug in `contr.equalprior_pairs`

### DIFF
--- a/R/contr.equalprior.R
+++ b/R/contr.equalprior.R
@@ -172,6 +172,7 @@ contr.equalprior <- function(n, contrasts = TRUE, sparse = FALSE) {
 #' @rdname contr.equalprior
 contr.equalprior_pairs <- function(n, contrasts = TRUE, sparse = FALSE) {
   contr <- contr.equalprior(n, contrasts, sparse) / sqrt(2)
+  contr
 }
 
 #' @export


### PR DESCRIPTION
A contrast function need to return the contrasts. Currently `contr.equalprior_pairs` does not return anything.