### PR TITLE
new `rope(x, complement = TRUE)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# bayestestR 0.15.3
+
+## New functionality
+
+* `rope()` (and by extention `p_rope()`) gain a new `complement` argument such
+  that `rope(x, complement = TRUE)` returns the ROPE posterior probability
+  together with the posterior probabilities above/below the ROPE (the 
+  _complementary_ probabilities).
+
 # bayestestR 0.15.2
 
 ## Changes

--- a/R/format.R
+++ b/R/format.R
@@ -21,6 +21,11 @@ format.describe_posterior <- function(x,
 
   # format columns and values of data frame
   out <- insight::format_table(x, digits = digits, format = format, ...)
+  if (inherits(x, "p_rope") && all(c("p_Superiority", "p_Inferiority") %in% colnames(out))) {
+    colnames(out)[colnames(out) == "p_Superiority"] <- "p (Superiority)"
+    colnames(out)[colnames(out) == "p_Inferiority"] <- "p (Inferiority)"
+  }
+
 
   # different CI-types as column names?
   if (ci_string != "CI" && any(endsWith(colnames(out), "CI"))) {

--- a/R/p_rope.R
+++ b/R/p_rope.R
@@ -3,6 +3,7 @@
 #' Compute the proportion of the whole posterior distribution that doesn't lie within a region of practical equivalence (ROPE). It is equivalent to running `rope(..., ci = 1)`.
 #'
 #' @inheritParams rope
+#' @param ... Other arguments passed to [rope()].
 #'
 #' @examples
 #' library(bayestestR)
@@ -227,9 +228,16 @@ p_rope.mcmc.list <- p_rope.mcmc
 
 #' @keywords internal
 .p_rope <- function(rope_rez) {
-  cols <- c("Parameter", "ROPE_low", "ROPE_high", "ROPE_Percentage", "Effects", "Component")
-  out <- as.data.frame(rope_rez)[cols[cols %in% names(rope_rez)]]
+  cols <- c("Parameter", "ROPE_low", "ROPE_high",
+            "ROPE_Percentage", "Superiority_Percentage", "Inferiority_Percentage",
+            "Effects", "Component")
+  out <- as.data.frame(rope_rez)[intersect(names(rope_rez), cols)]
+
   names(out)[names(out) == "ROPE_Percentage"] <- "p_ROPE"
+  if (all(c("Superiority_Percentage", "Inferiority_Percentage") %in% names(out))) {
+    names(out)[names(out) == "Superiority_Percentage"] <- "p_Superiority"
+    names(out)[names(out) == "Inferiority_Percentage"] <- "p_Inferiority"
+  }
 
   class(out) <- c("p_rope", "see_p_rope", "data.frame")
   out

--- a/R/print.rope.R
+++ b/R/print.rope.R
@@ -28,7 +28,9 @@ print.rope <- function(x, digits = 2, ...) {
 
   # These are the base columns we want to print
   cols <- c(
-    attr(x, "idvars"), "Parameter", "ROPE_Percentage", "Effects", "Component",
+    attr(x, "idvars"), "Parameter",
+    "ROPE_Percentage", "Superiority_Percentage", "Inferiority_Percentage",
+    "Effects", "Component",
     if (is_multivariate) c("ROPE_low", "ROPE_high")
   )
 
@@ -49,8 +51,11 @@ print.rope <- function(x, digits = 2, ...) {
   x <- subset(x, select = intersect(cols, colnames(x)))
 
   # This is just cosmetics, to have nicer column names and values
-  x$ROPE_Percentage <- sprintf("%.*f %%", digits, x$ROPE_Percentage * 100)
-  colnames(x)[which(colnames(x) == "ROPE_Percentage")] <- "inside ROPE"
+  iv <- intersect(colnames(x), c("ROPE_Percentage", "Superiority_Percentage", "Inferiority_Percentage"))
+  x[iv] <- lapply(x[iv], function(v) sprintf("%.*f %%", digits, v * 100))
+  colnames(x)[colnames(x) == "ROPE_Percentage"] <- "Inside ROPE"
+  colnames(x)[colnames(x) == "Superiority_Percentage"] <- "Above ROPE"
+  colnames(x)[colnames(x) == "Inferiority_Percentage"] <- "Below ROPE"
 
   # Add ROPE width for multivariate models
   if (isTRUE(is_multivariate)) {

--- a/man/p_rope.Rd
+++ b/man/p_rope.Rd
@@ -39,7 +39,7 @@ p_rope(x, ...)
 \item{x}{Vector representing a posterior distribution. Can also be a
 \code{stanreg} or \code{brmsfit} model.}
 
-\item{...}{Currently not used.}
+\item{...}{Other arguments passed to \code{\link[=rope]{rope()}}.}
 
 \item{range}{ROPE's lower and higher bounds. Should be \code{"default"} or
 depending on the number of outcome variables a vector or a list. For models

--- a/man/rope.Rd
+++ b/man/rope.Rd
@@ -10,13 +10,22 @@
 \usage{
 rope(x, ...)
 
-\method{rope}{numeric}(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...)
+\method{rope}{numeric}(
+  x,
+  range = "default",
+  ci = 0.95,
+  ci_method = "ETI",
+  complement = FALSE,
+  verbose = TRUE,
+  ...
+)
 
 \method{rope}{data.frame}(
   x,
   range = "default",
   ci = 0.95,
   ci_method = "ETI",
+  complement = FALSE,
   rvar_col = NULL,
   verbose = TRUE,
   ...
@@ -27,6 +36,7 @@ rope(x, ...)
   range = "default",
   ci = 0.95,
   ci_method = "ETI",
+  complement = FALSE,
   effects = c("fixed", "random", "all"),
   component = c("location", "all", "conditional", "smooth_terms", "sigma",
     "distributional", "auxiliary"),
@@ -40,6 +50,7 @@ rope(x, ...)
   range = "default",
   ci = 0.95,
   ci_method = "ETI",
+  complement = FALSE,
   effects = c("fixed", "random", "all"),
   component = c("conditional", "zi", "zero_inflated", "all"),
   parameters = NULL,
@@ -76,6 +87,10 @@ proportion of HDI, to use for the percentage in ROPE.}
 
 \item{ci_method}{The type of interval to use to quantify the percentage in
 ROPE. Can be 'HDI' (default) or 'ETI'. See \code{\link[=ci]{ci()}}.}
+
+\item{complement}{Should the probabilities above/below the ROPE (the
+\emph{complementary} probabilities) be returned as well? See
+\code{\link[=equivalence_test]{equivalence_test()}} as well.}
 
 \item{verbose}{Toggle off warnings.}
 


### PR DESCRIPTION
New feature to report posterior probabilities above/below the rope for a more full picture.

```R
library(bayestestR)

x <- rnorm(4000, sd = 5)

rope(x, complement = TRUE)
#> # Proportion of samples inside the ROPE [-0.10, 0.10]:
#> 
#> Inside ROPE | Above ROPE | Below ROPE
#> -------------------------------------
#> 1.61 %      |    49.08 % |    49.32 %
```