### PR TITLE
Docs, no multiple options in arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bayestestR
 Title: Understand and Describe Bayesian Models and Posterior Distributions
-Version: 0.15.2.4
+Version: 0.15.2.5
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/R/bayesfactor.R
+++ b/R/bayesfactor.R
@@ -53,13 +53,12 @@ bayesfactor <- function(...,
                         direction = "two-sided",
                         null = 0,
                         hypothesis = NULL,
-                        effects = c("fixed", "random", "all"),
+                        effects = "fixed",
                         verbose = TRUE,
                         denominator = 1,
                         match_models = FALSE,
                         prior_odds = NULL) {
   mods <- list(...)
-  effects <- match.arg(effects)
 
   if (length(mods) > 1) {
     bayesfactor_models(..., denominator = denominator)

--- a/R/bayesfactor_inclusion.R
+++ b/R/bayesfactor_inclusion.R
@@ -1,8 +1,7 @@
 #' Inclusion Bayes Factors for testing predictors across Bayesian models
 #'
-#' The `bf_*` function is an alias of the main function.
-#' \cr \cr
-#' For more info, see [the Bayes factors vignette](https://easystats.github.io/bayestestR/articles/bayes_factors.html).
+#' The `bf_*` function is an alias of the main function. For more info, see
+#' [the Bayes factors vignette](https://easystats.github.io/bayestestR/articles/bayes_factors.html).
 #'
 #' @author Mattan S. Ben-Shachar
 #' @param models An object of class [bayesfactor_models()] or `BFBayesFactor`.

--- a/R/bayesfactor_models.R
+++ b/R/bayesfactor_models.R
@@ -1,8 +1,7 @@
 #' Bayes Factors (BF) for model comparison
 #'
-#' @description This function computes or extracts Bayes factors from fitted models.
-#' \cr \cr
-#' The `bf_*` function is an alias of the main function.
+#' @description This function computes or extracts Bayes factors from fitted
+#' models. The `bf_*` function is an alias of the main function.
 #'
 #' @author Mattan S. Ben-Shachar
 #'

--- a/R/bayesfactor_parameters.R
+++ b/R/bayesfactor_parameters.R
@@ -42,6 +42,8 @@
 #'   arguments to internal [logspline::logspline()].)
 #' @inheritParams hdi
 #'
+#' @inheritSection hdi Model components
+#'
 #' @return A data frame containing the (log) Bayes factor representing evidence
 #'   *against* the null  (Use `as.numeric()` to extract the non-log Bayes
 #'   factors; see examples).
@@ -289,14 +291,12 @@ bayesfactor_parameters.stanreg <- function(posterior,
                                            prior = NULL,
                                            direction = "two-sided",
                                            null = 0,
-                                           effects = c("fixed", "random", "all"),
-                                           component = c("conditional", "location", "smooth_terms", "sigma", "zi", "zero_inflated", "all"),
+                                           effects = "fixed",
+                                           component = "conditional",
                                            parameters = NULL,
                                            ...,
                                            verbose = TRUE) {
   cleaned_parameters <- insight::clean_parameters(posterior)
-  effects <- match.arg(effects)
-  component <- match.arg(component)
 
   samps <- .clean_priors_and_posteriors(posterior, prior,
     effects = effects, component = component,
@@ -323,12 +323,10 @@ bayesfactor_parameters.stanreg <- function(posterior,
 }
 
 
-#' @rdname bayesfactor_parameters
 #' @export
 bayesfactor_parameters.brmsfit <- bayesfactor_parameters.stanreg
 
 
-#' @rdname bayesfactor_parameters
 #' @export
 bayesfactor_parameters.blavaan <- function(posterior,
                                            prior = NULL,

--- a/R/bayesfactor_restricted.R
+++ b/R/bayesfactor_restricted.R
@@ -129,12 +129,9 @@ bf_restricted <- bayesfactor_restricted
 #' @export
 bayesfactor_restricted.stanreg <- function(posterior, hypothesis, prior = NULL,
                                            verbose = TRUE,
-                                           effects = c("fixed", "random", "all"),
-                                           component = c("conditional", "zi", "zero_inflated", "all"),
+                                           effects = "fixed",
+                                           component = "conditional",
                                            ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   samps <- .clean_priors_and_posteriors(posterior, prior,
     effects = effects, component = component,
     verbose = verbose

--- a/R/bci.R
+++ b/R/bci.R
@@ -9,6 +9,8 @@
 #' @inherit hdi seealso
 #' @family ci
 #'
+#' @inheritSection hdi Model components
+#'
 #' @references
 #' DiCiccio, T. J. and B. Efron. (1996). Bootstrap Confidence Intervals.
 #' Statistical Science. 11(3): 189–212. 10.1214/ss/1032280214
@@ -75,7 +77,6 @@ bci.draws <- function(x, ci = 0.95, verbose = TRUE, ...) {
 bci.rvar <- bci.draws
 
 
-#' @rdname bci
 #' @export
 bci.MCMCglmm <- function(x, ci = 0.95, verbose = TRUE, ...) {
   nF <- x$Fixed$nfl
@@ -98,10 +99,9 @@ bci.mcmc <- function(x, ci = 0.95, verbose = TRUE, ...) {
 #' @export
 bci.bamlss <- function(x,
                        ci = 0.95,
-                       component = c("all", "conditional", "location"),
+                       component = "all",
                        verbose = TRUE,
                        ...) {
-  component <- match.arg(component)
   d <- insight::get_parameters(x, component = component)
   dat <- .compute_interval_dataframe(x = d, ci = ci, verbose = verbose, fun = "bci")
   attr(dat, "data") <- insight::safe_deparse_symbol(substitute(x))
@@ -131,15 +131,13 @@ bci.mcmc.list <- bci.bcplm
 bci.BGGM <- bci.bcplm
 
 
-#' @rdname bci
 #' @export
 bci.sim.merMod <- function(x,
                            ci = 0.95,
-                           effects = c("fixed", "random", "all"),
+                           effects = "fixed",
                            parameters = NULL,
                            verbose = TRUE,
                            ...) {
-  effects <- match.arg(effects)
   dat <- .compute_interval_simMerMod(
     x = x,
     ci = ci,
@@ -154,7 +152,6 @@ bci.sim.merMod <- function(x,
 }
 
 
-#' @rdname bci
 #' @export
 bci.sim <- function(x, ci = 0.95, parameters = NULL, verbose = TRUE, ...) {
   dat <- .compute_interval_sim(
@@ -170,7 +167,6 @@ bci.sim <- function(x, ci = 0.95, parameters = NULL, verbose = TRUE, ...) {
 }
 
 
-#' @rdname bci
 #' @export
 bci.emmGrid <- function(x, ci = 0.95, verbose = TRUE, ...) {
   xdf <- insight::get_parameters(x)
@@ -183,7 +179,6 @@ bci.emmGrid <- function(x, ci = 0.95, verbose = TRUE, ...) {
 #' @export
 bci.emm_list <- bci.emmGrid
 
-#' @rdname bci
 #' @export
 bci.slopes <- function(x, ci = 0.95, verbose = TRUE, ...) {
   xrvar <- .get_marginaleffects_draws(x)
@@ -199,18 +194,14 @@ bci.comparisons <- bci.slopes
 #' @export
 bci.predictions <- bci.slopes
 
-#' @rdname bci
 #' @export
 bci.stanreg <- function(x,
                         ci = 0.95,
-                        effects = c("fixed", "random", "all"),
-                        component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
+                        effects = "fixed",
+                        component = "location",
                         parameters = NULL,
                         verbose = TRUE,
                         ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   out <- .prepare_output(
     bci(
       insight::get_parameters(
@@ -242,12 +233,13 @@ bci.blavaan <- bci.stanreg
 
 #' @rdname bci
 #' @export
-bci.brmsfit <- function(x, ci = 0.95, effects = c("fixed", "random", "all"),
-                        component = c("conditional", "zi", "zero_inflated", "all"),
-                        parameters = NULL, verbose = TRUE, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
+bci.brmsfit <- function(x,
+                        ci = 0.95,
+                        effects = "fixed",
+                        component = "conditional",
+                        parameters = NULL,
+                        verbose = TRUE,
+                        ...) {
   out <- .prepare_output(
     bci(
       insight::get_parameters(
@@ -269,7 +261,6 @@ bci.brmsfit <- function(x, ci = 0.95, effects = c("fixed", "random", "all"),
 }
 
 
-#' @rdname bci
 #' @export
 bci.BFBayesFactor <- function(x, ci = 0.95, verbose = TRUE, ...) {
   out <- bci(insight::get_parameters(x), ci = ci, verbose = verbose, ...)

--- a/R/check_prior.R
+++ b/R/check_prior.R
@@ -50,19 +50,16 @@ check_prior <- function(model, method = "gelman", simulate_priors = TRUE, ...) {
 }
 
 
+#' @rdname check_prior
 #' @export
 check_prior.brmsfit <- function(model,
                                 method = "gelman",
                                 simulate_priors = TRUE,
-                                effects = c("fixed", "random", "all"),
-                                component = c("conditional", "zi", "zero_inflated", "all"),
+                                effects = "fixed",
+                                component = "conditional",
                                 parameters = NULL,
                                 verbose = TRUE,
                                 ...) {
-  # check arguments
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   posteriors <- insight::get_parameters(
     model,
     effects = effects,

--- a/R/ci.R
+++ b/R/ci.R
@@ -72,8 +72,8 @@ ci <- function(x, ...) {
 .ci_bayesian <- function(x,
                          ci = 0.95,
                          method = "ETI",
-                         effects = c("fixed", "random", "all"),
-                         component = c("conditional", "zi", "zero_inflated", "all"),
+                         effects = "fixed",
+                         component = "conditional",
                          parameters = NULL,
                          verbose = TRUE,
                          BF = 1,
@@ -159,7 +159,13 @@ ci.numeric <- function(x, ci = 0.95, method = "ETI", verbose = TRUE, BF = 1, ...
 #' @rdname ci
 #' @inheritParams p_direction
 #' @export
-ci.data.frame <- function(x, ci = 0.95, method = "ETI", BF = 1, rvar_col = NULL, verbose = TRUE, ...) {
+ci.data.frame <- function(x,
+                          ci = 0.95,
+                          method = "ETI",
+                          BF = 1,
+                          rvar_col = NULL,
+                          verbose = TRUE,
+                          ...) {
   x_rvar <- .possibly_extract_rvar_col(x, rvar_col)
   if (length(x_rvar) > 0L) {
     cl <- match.call()
@@ -180,7 +186,14 @@ ci.data.frame <- function(x, ci = 0.95, method = "ETI", BF = 1, rvar_col = NULL,
 
 #' @export
 ci.draws <- function(x, ci = 0.95, method = "ETI", verbose = TRUE, BF = 1, ...) {
-  .ci_bayesian(.posterior_draws_to_df(x), ci = ci, method = method, verbose = verbose, BF = BF, ...)
+  .ci_bayesian(
+    .posterior_draws_to_df(x),
+    ci = ci,
+    method = method,
+    verbose = verbose,
+    BF = BF,
+    ...
+  )
 }
 
 #' @export
@@ -202,9 +215,9 @@ ci.emmGrid <- function(x, ci = NULL, ...) {
   out
 }
 
-
 #' @export
 ci.emm_list <- ci.emmGrid
+
 
 #' @export
 ci.slopes <- function(x, ci = NULL, ...) {
@@ -228,12 +241,11 @@ ci.comparisons <- ci.slopes
 ci.predictions <- ci.slopes
 
 
-#' @rdname ci
 #' @export
 ci.sim.merMod <- function(x,
                           ci = 0.95,
                           method = "ETI",
-                          effects = c("fixed", "random", "all"),
+                          effects = "fixed",
                           parameters = NULL,
                           verbose = TRUE,
                           ...) {
@@ -249,7 +261,6 @@ ci.sim.merMod <- function(x,
 }
 
 
-#' @rdname ci
 #' @export
 ci.sim <- function(x,
                    ci = 0.95,
@@ -268,21 +279,12 @@ ci.sim <- function(x,
 }
 
 
-#' @rdname ci
 #' @export
 ci.stanreg <- function(x,
                        ci = 0.95,
                        method = "ETI",
-                       effects = c("fixed", "random", "all"),
-                       component = c(
-                         "location",
-                         "all",
-                         "conditional",
-                         "smooth_terms",
-                         "sigma",
-                         "distributional",
-                         "auxiliary"
-                       ),
+                       effects = "fixed",
+                       component = "location",
                        parameters = NULL,
                        verbose = TRUE,
                        BF = 1,
@@ -306,8 +308,8 @@ ci.stanreg <- function(x,
 ci.brmsfit <- function(x,
                        ci = 0.95,
                        method = "ETI",
-                       effects = c("fixed", "random", "all"),
-                       component = c("conditional", "zi", "zero_inflated", "all"),
+                       effects = "fixed",
+                       component = "conditional",
                        parameters = NULL,
                        verbose = TRUE,
                        BF = 1,
@@ -331,12 +333,10 @@ ci.stanfit <- ci.stanreg
 #' @export
 ci.blavaan <- ci.stanreg
 
-#' @rdname ci
 #' @export
 ci.BFBayesFactor <- ci.numeric
 
 
-#' @rdname ci
 #' @export
 ci.MCMCglmm <- function(x, ci = 0.95, method = "ETI", verbose = TRUE, ...) {
   nF <- x$Fixed$nfl
@@ -354,10 +354,9 @@ ci.MCMCglmm <- function(x, ci = 0.95, method = "ETI", verbose = TRUE, ...) {
 ci.bamlss <- function(x,
                       ci = 0.95,
                       method = "ETI",
-                      component = c("all", "conditional", "location"),
+                      component = "all",
                       verbose = TRUE,
                       ...) {
-  component <- match.arg(component)
   ci(
     insight::get_parameters(x, component = component),
     ci = ci,

--- a/R/ci.R
+++ b/R/ci.R
@@ -18,6 +18,8 @@
 #' @inherit hdi seealso
 #' @family ci
 #'
+#' @inheritSection hdi Model components
+#'
 #' @return A data frame with following columns:
 #'
 #' - `Parameter` The model parameter(s), if `x` is a model-object. If `x` is a

--- a/R/ci.R
+++ b/R/ci.R
@@ -49,19 +49,19 @@
 #' ci(df, method = "ETI", ci = c(0.80, 0.89, 0.95))
 #' ci(df, method = "HDI", ci = c(0.80, 0.89, 0.95))
 #'
-#' model <- suppressWarnings(
-#'   stan_glm(mpg ~ wt, data = mtcars, chains = 2, iter = 200, refresh = 0)
-#' )
+#' model <- suppressWarnings(rstanarm::stan_glm(
+#'   mpg ~ wt, data = mtcars, chains = 2, iter = 200, refresh = 0
+#' ))
 #' ci(model, method = "ETI", ci = c(0.80, 0.89))
 #' ci(model, method = "HDI", ci = c(0.80, 0.89))
 #'
 #' @examplesIf require("BayesFactor", quietly = TRUE)
-#' bf <- ttestBF(x = rnorm(100, 1, 1))
+#' bf <- BayesFactor::ttestBF(x = rnorm(100, 1, 1))
 #' ci(bf, method = "ETI")
 #' ci(bf, method = "HDI")
 #'
 #' @examplesIf require("emmeans", quietly = TRUE) && require("rstanarm", quietly = TRUE)
-#' model <- emtrends(model, ~1, "wt", data = mtcars)
+#' model <- emmeans::emtrends(model, ~1, "wt", data = mtcars)
 #' ci(model, method = "ETI")
 #' ci(model, method = "HDI")
 #' @export

--- a/R/describe_posterior.R
+++ b/R/describe_posterior.R
@@ -36,6 +36,8 @@
 #' @inheritParams si
 #' @inheritParams hdi
 #'
+#' @inheritSection hdi Model components
+#'
 #' @details
 #' One or more components of point estimates (like posterior mean or median),
 #' intervals and tests can be omitted from the summary output by setting the
@@ -82,7 +84,10 @@
 #' # rstanarm models
 #' # -----------------------------------------------
 #' model <- suppressWarnings(
-#'   rstanarm::stan_glm(mpg ~ wt + gear, data = mtcars, chains = 2, iter = 200, refresh = 0)
+#'   rstanarm::stan_glm(
+#'     mpg ~ wt + gear, data = mtcars, chains = 2, iter = 200,
+#'     refresh = 0
+#'   )
 #' )
 #' describe_posterior(model)
 #' describe_posterior(model, centrality = "all", dispersion = TRUE, test = "all")
@@ -186,7 +191,10 @@ describe_posterior.default <- function(posterior, ...) {
   if (is.null(ci)) {
     uncertainty <- data.frame(Parameter = NA)
   } else {
-    ci_method <- match.arg(tolower(ci_method), c("hdi", "spi", "quantile", "ci", "eti", "si", "bci", "bcai"))
+    ci_method <- insight::validate_argument(
+      tolower(ci_method),
+      c("hdi", "spi", "quantile", "ci", "eti", "si", "bci", "bcai")
+    )
     # not sure why "si" requires the model object
     if (ci_method == "si") {
       uncertainty <- ci(x, BF = BF, method = ci_method, prior = bf_prior, verbose = verbose, ...)
@@ -490,12 +498,22 @@ describe_posterior.default <- function(posterior, ...) {
   # column consist only of missing values, we remove those columns as well
 
   remove_columns <- ".rowid"
-  if (insight::n_unique(out$Effects, remove_na = TRUE) < 2) remove_columns <- c(remove_columns, "Effects")
-  if (insight::n_unique(out$Component, remove_na = TRUE) < 2) remove_columns <- c(remove_columns, "Component")
-  if (insight::n_unique(out$Response, remove_na = TRUE) < 2) remove_columns <- c(remove_columns, "Response")
+  if (insight::n_unique(out$Effects, remove_na = TRUE) < 2) {
+    remove_columns <- c(remove_columns, "Effects")
+  }
+  if (insight::n_unique(out$Component, remove_na = TRUE) < 2) {
+    remove_columns <- c(remove_columns, "Component")
+  }
+  if (insight::n_unique(out$Response, remove_na = TRUE) < 2) {
+    remove_columns <- c(remove_columns, "Response")
+  }
 
   # Restore columns order
-  out <- datawizard::data_remove(out[order(out$.rowid), ], remove_columns, verbose = FALSE)
+  out <- datawizard::data_remove(
+    out[order(out$.rowid), ],
+    remove_columns,
+    verbose = FALSE
+  )
 
   # Add iterations
   if (keep_iterations) {
@@ -944,12 +962,8 @@ describe_posterior.stanreg <- function(posterior,
                                        bf_prior = NULL,
                                        diagnostic = c("ESS", "Rhat"),
                                        priors = FALSE,
-                                       effects = c("fixed", "random", "all"),
-                                       component = c(
-                                         "location", "all", "conditional",
-                                         "smooth_terms", "sigma", "distributional",
-                                         "auxiliary"
-                                       ),
+                                       effects = "fixed",
+                                       component = "location",
                                        parameters = NULL,
                                        BF = 1,
                                        verbose = TRUE,
@@ -958,9 +972,6 @@ describe_posterior.stanreg <- function(posterior,
     "si" %in% tolower(ci_method)) && is.null(bf_prior)) {
     bf_prior <- suppressMessages(unupdate(posterior))
   }
-
-  effects <- match.arg(effects)
-  component <- match.arg(component)
 
   out <- .describe_posterior(
     posterior,
@@ -1019,18 +1030,11 @@ describe_posterior.stanmvreg <- function(posterior,
                                          bf_prior = NULL,
                                          diagnostic = c("ESS", "Rhat"),
                                          priors = FALSE,
-                                         effects = c("fixed", "random", "all"),
-                                         component = c(
-                                           "location", "all", "conditional",
-                                           "smooth_terms", "sigma", "distributional",
-                                           "auxiliary"
-                                         ),
+                                         effects = "fixed",
+                                         component = "location",
                                          parameters = NULL,
                                          verbose = TRUE,
                                          ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   out <- .describe_posterior(
     posterior,
     centrality = centrality,
@@ -1088,12 +1092,11 @@ describe_posterior.stanfit <- function(posterior,
                                        rope_ci = 0.95,
                                        keep_iterations = FALSE,
                                        diagnostic = c("ESS", "Rhat"),
-                                       effects = c("fixed", "random", "all"),
+                                       effects = "fixed",
                                        parameters = NULL,
                                        priors = FALSE,
                                        verbose = TRUE,
                                        ...) {
-  effects <- match.arg(effects)
   out <- .describe_posterior(
     posterior,
     centrality = centrality,
@@ -1144,20 +1147,13 @@ describe_posterior.brmsfit <- function(posterior,
                                        keep_iterations = FALSE,
                                        bf_prior = NULL,
                                        diagnostic = c("ESS", "Rhat"),
-                                       effects = c("fixed", "random", "all"),
-                                       component = c(
-                                         "conditional", "zi", "zero_inflated",
-                                         "all", "location", "distributional",
-                                         "auxiliary"
-                                       ),
+                                       effects = "fixed",
+                                       component = "conditional",
                                        parameters = NULL,
                                        BF = 1,
                                        priors = FALSE,
                                        verbose = TRUE,
                                        ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   if ((any(c("all", "bf", "bayesfactor", "bayes_factor") %in% tolower(test)) ||
     "si" %in% tolower(ci_method)) && is.null(bf_prior)) {
     bf_prior <- suppressMessages(unupdate(posterior))
@@ -1305,11 +1301,10 @@ describe_posterior.bamlss <- function(posterior,
                                       rope_range = "default",
                                       rope_ci = 0.95,
                                       keep_iterations = FALSE,
-                                      component = c("all", "conditional", "location"),
+                                      component = "all",
                                       parameters = NULL,
                                       verbose = TRUE,
                                       ...) {
-  component <- match.arg(component)
   out <- .describe_posterior(
     posterior,
     centrality = centrality,

--- a/R/describe_posterior.R
+++ b/R/describe_posterior.R
@@ -1133,8 +1133,6 @@ describe_posterior.stanfit <- function(posterior,
 }
 
 
-#' @inheritParams describe_posterior.stanreg
-#' @rdname describe_posterior
 #' @export
 describe_posterior.brmsfit <- function(posterior,
                                        centrality = "median",

--- a/R/describe_posterior.R
+++ b/R/describe_posterior.R
@@ -96,11 +96,11 @@
 #'
 #' # emmeans estimates
 #' # -----------------------------------------------
-#' describe_posterior(emtrends(model, ~1, "wt"))
+#' describe_posterior(emmeans::emtrends(model, ~1, "wt"))
 #'
 #' # BayesFactor objects
 #' # -----------------------------------------------
-#' bf <- ttestBF(x = rnorm(100, 1, 1))
+#' bf <- BayesFactor::ttestBF(x = rnorm(100, 1, 1))
 #' describe_posterior(bf)
 #' describe_posterior(bf, centrality = "all", dispersion = TRUE, test = "all")
 #' describe_posterior(bf, ci = c(0.80, 0.90))

--- a/R/describe_prior.R
+++ b/R/describe_prior.R
@@ -39,14 +39,8 @@ describe_prior <- function(model, ...) {
 
 #' @rdname describe_prior
 #' @export
-describe_prior.brmsfit <- function(model,
-                                   effects = c("fixed", "random", "all"),
-                                   component = c(
-                                     "conditional", "zi", "zero_inflated",
-                                     "all", "location", "distributional", "auxiliary"
-                                   ),
-                                   parameters = NULL, ...) {
-  .describe_prior(model, parameters = parameters)
+describe_prior.brmsfit <- function(model, parameters = NULL, ...) {
+  .describe_prior(model, parameters = parameters, ...)
 }
 
 
@@ -92,7 +86,6 @@ describe_prior.brmsfit <- function(model,
 
 #' @export
 describe_prior.stanreg <- .describe_prior
-
 
 #' @export
 describe_prior.bcplm <- .describe_prior

--- a/R/diagnostic_posterior.R
+++ b/R/diagnostic_posterior.R
@@ -196,7 +196,6 @@ diagnostic_posterior.stanmvreg <- function(posterior,
 
 
 #' @inheritParams insight::get_parameters
-#' @rdname diagnostic_posterior
 #' @export
 diagnostic_posterior.brmsfit <- function(posterior,
                                          diagnostic = "all",

--- a/R/diagnostic_posterior.R
+++ b/R/diagnostic_posterior.R
@@ -7,6 +7,8 @@
 #' @param diagnostic Diagnostic metrics to compute.  Character (vector) or list
 #'   with one or more of these options: `"ESS"`, `"Rhat"`, `"MCSE"` or `"all"`.
 #'
+#' @inheritSection hdi Model components
+#'
 #' @details
 #'   **Effective Sample (ESS)** should be as large as possible, although for
 #'   most applications, an effective sample size greater than 1000 is sufficient
@@ -64,7 +66,12 @@ diagnostic_posterior.default <- function(posterior, diagnostic = c("ESS", "Rhat"
 #' @inheritParams insight::get_parameters
 #' @rdname diagnostic_posterior
 #' @export
-diagnostic_posterior.stanreg <- function(posterior, diagnostic = "all", effects = "fixed", component = "location", parameters = NULL, ...) {
+diagnostic_posterior.stanreg <- function(posterior,
+                                         diagnostic = "all",
+                                         effects = "fixed",
+                                         component = "location",
+                                         parameters = NULL,
+                                         ...) {
   # Find parameters
   params <- insight::find_parameters(
     posterior,

--- a/R/diagnostic_posterior.R
+++ b/R/diagnostic_posterior.R
@@ -64,10 +64,8 @@ diagnostic_posterior.default <- function(posterior, diagnostic = c("ESS", "Rhat"
 #' @inheritParams insight::get_parameters
 #' @rdname diagnostic_posterior
 #' @export
-diagnostic_posterior.stanreg <- function(posterior, diagnostic = "all", effects = c("fixed", "random", "all"), component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"), parameters = NULL, ...) {
+diagnostic_posterior.stanreg <- function(posterior, diagnostic = "all", effects = "fixed", component = "location", parameters = NULL, ...) {
   # Find parameters
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   params <- insight::find_parameters(
     posterior,
     effects = effects,
@@ -81,7 +79,12 @@ diagnostic_posterior.stanreg <- function(posterior, diagnostic = "all", effects 
     return(data.frame(Parameter = params))
   }
 
-  diagnostic <- match.arg(diagnostic, c("ESS", "Rhat", "MCSE", "all"), several.ok = TRUE)
+  diagnostic <- match.arg(
+    diagnostic,
+    c("ESS", "Rhat", "MCSE", "all"),
+    several.ok = TRUE
+  )
+
   if ("all" %in% diagnostic) {
     diagnostic <- c("ESS", "Rhat", "MCSE", "khat")
   } else {
@@ -117,11 +120,10 @@ diagnostic_posterior.stanreg <- function(posterior, diagnostic = "all", effects 
 #' @export
 diagnostic_posterior.stanmvreg <- function(posterior,
                                            diagnostic = "all",
-                                           effects = c("fixed", "random", "all"),
+                                           effects = "fixed",
                                            parameters = NULL,
                                            ...) {
   # Find parameters
-  effects <- match.arg(effects)
   all_params <- insight::find_parameters(
     posterior,
     effects = effects,
@@ -139,7 +141,12 @@ diagnostic_posterior.stanmvreg <- function(posterior,
     return(data.frame(Parameter = params))
   }
 
-  diagnostic <- match.arg(diagnostic, c("ESS", "Rhat", "MCSE", "all"), several.ok = TRUE)
+  diagnostic <- match.arg(
+    diagnostic,
+    c("ESS", "Rhat", "MCSE", "all"),
+    several.ok = TRUE
+  )
+
   if ("all" %in% diagnostic) {
     diagnostic <- c("ESS", "Rhat", "MCSE", "khat")
   } else {
@@ -168,7 +175,12 @@ diagnostic_posterior.stanmvreg <- function(posterior,
 
   diagnostic_df$Response <- gsub("(b\\[)*(.*)\\|(.*)", "\\2", diagnostic_df$Parameter)
   for (i in unique(diagnostic_df$Response)) {
-    diagnostic_df$Parameter <- gsub(sprintf("%s|", i), "", diagnostic_df$Parameter, fixed = TRUE)
+    diagnostic_df$Parameter <- gsub(
+      sprintf("%s|", i),
+      "",
+      diagnostic_df$Parameter,
+      fixed = TRUE
+    )
   }
 
   # Select rows
@@ -181,13 +193,11 @@ diagnostic_posterior.stanmvreg <- function(posterior,
 #' @export
 diagnostic_posterior.brmsfit <- function(posterior,
                                          diagnostic = "all",
-                                         effects = c("fixed", "random", "all"),
-                                         component = c("conditional", "zi", "zero_inflated", "all"),
+                                         effects = "fixed",
+                                         component = "conditional",
                                          parameters = NULL,
                                          ...) {
   # Find parameters
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   params <- insight::find_parameters(posterior,
     effects = effects,
     component = component,
@@ -201,7 +211,12 @@ diagnostic_posterior.brmsfit <- function(posterior,
   }
 
   # Get diagnostic
-  diagnostic <- match.arg(diagnostic, c("ESS", "Rhat", "MCSE", "all"), several.ok = TRUE)
+  diagnostic <- match.arg(
+    diagnostic,
+    c("ESS", "Rhat", "MCSE", "all"),
+    several.ok = TRUE
+  )
+
   if ("all" %in% diagnostic) {
     diagnostic <- c("ESS", "Rhat", "MCSE", "khat") # Add MCSE
   } else if ("Rhat" %in% diagnostic) {
@@ -234,10 +249,14 @@ diagnostic_posterior.brmsfit <- function(posterior,
 
 #' @inheritParams insight::get_parameters
 #' @export
-diagnostic_posterior.stanfit <- function(posterior, diagnostic = "all", effects = c("fixed", "random", "all"), parameters = NULL, ...) {
+diagnostic_posterior.stanfit <- function(posterior, diagnostic = "all", effects = "fixed", parameters = NULL, ...) {
   # Find parameters
-  effects <- match.arg(effects)
-  params <- insight::find_parameters(posterior, effects = effects, parameters = parameters, flatten = TRUE)
+  params <- insight::find_parameters(
+    posterior,
+    effects = effects,
+    parameters = parameters,
+    flatten = TRUE
+  )
 
   # If no diagnostic
   if (is.null(diagnostic)) {
@@ -245,7 +264,11 @@ diagnostic_posterior.stanfit <- function(posterior, diagnostic = "all", effects 
   }
 
   # Get diagnostic
-  diagnostic <- match.arg(diagnostic, c("ESS", "Rhat", "MCSE", "all"), several.ok = TRUE)
+  diagnostic <- match.arg(
+    diagnostic,
+    c("ESS", "Rhat", "MCSE", "all"),
+    several.ok = TRUE
+  )
   if ("all" %in% diagnostic) {
     diagnostic <- c("ESS", "Rhat", "MCSE")
   }
@@ -295,7 +318,11 @@ diagnostic_posterior.blavaan <- function(posterior, diagnostic = "all", ...) {
     return(out)
   }
 
-  diagnostic <- match.arg(diagnostic, c("ESS", "Rhat", "MCSE", "all"), several.ok = TRUE)
+  diagnostic <- match.arg(
+    diagnostic,
+    c("ESS", "Rhat", "MCSE", "all"),
+    several.ok = TRUE
+  )
   if ("all" %in% diagnostic) {
     diagnostic <- c("ESS", "Rhat", "MCSE")
   } else {

--- a/R/effective_sample.R
+++ b/R/effective_sample.R
@@ -113,7 +113,6 @@ effective_sample.brmsfit <- function(model,
 }
 
 
-#' @rdname effective_sample
 #' @export
 effective_sample.stanreg <- function(model,
                                      effects = "fixed",

--- a/R/equivalence_test.R
+++ b/R/equivalence_test.R
@@ -17,6 +17,8 @@
 #'
 #' @inheritParams rope
 #'
+#' @inheritSection hdi Model components
+#'
 #' @details Using the [ROPE][rope] and the [HDI][hdi], \cite{Kruschke (2018)}
 #'   suggests using the percentage of the `95%` (or `89%`, considered more stable)
 #'   HDI that falls within the ROPE as a decision rule. If the HDI
@@ -282,28 +284,24 @@ equivalence_test.BFBayesFactor <- function(x, range = "default", ci = 0.95, verb
 }
 
 
-#' @rdname equivalence_test
 #' @export
 equivalence_test.stanreg <- function(x,
                                      range = "default",
                                      ci = 0.95,
-                                     effects = c("fixed", "random", "all"),
-                                     component = c(
-                                       "location",
-                                       "all",
-                                       "conditional",
-                                       "smooth_terms",
-                                       "sigma",
-                                       "distributional",
-                                       "auxiliary"
-                                     ),
+                                     effects = "fixed",
+                                     component = "location",
                                      parameters = NULL,
                                      verbose = TRUE,
                                      ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
-  out <- .equivalence_test_models(x, range, ci, effects, component, parameters, verbose)
+  out <- .equivalence_test_models(
+    x,
+    range,
+    ci,
+    effects,
+    component,
+    parameters,
+    verbose
+  )
 
   out <- .prepare_output(
     out,
@@ -329,15 +327,20 @@ equivalence_test.blavaan <- equivalence_test.stanreg
 equivalence_test.brmsfit <- function(x,
                                      range = "default",
                                      ci = 0.95,
-                                     effects = c("fixed", "random", "all"),
-                                     component = c("conditional", "zi", "zero_inflated", "all"),
+                                     effects = "fixed",
+                                     component = "conditional",
                                      parameters = NULL,
                                      verbose = TRUE,
                                      ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
-  out <- .equivalence_test_models(x, range, ci, effects, component, parameters, verbose)
+  out <- .equivalence_test_models(
+    x,
+    range,
+    ci,
+    effects,
+    component,
+    parameters,
+    verbose
+  )
 
   out <- .prepare_output(
     out,
@@ -433,11 +436,10 @@ equivalence_test.bayesQR <- equivalence_test.bcplm
 equivalence_test.bamlss <- function(x,
                                     range = "default",
                                     ci = 0.95,
-                                    component = c("all", "conditional", "location"),
+                                    component = "all",
                                     parameters = NULL,
                                     verbose = TRUE,
                                     ...) {
-  component <- match.arg(component)
   out <- .equivalence_test_models(
     insight::get_parameters(x, component = component),
     range,

--- a/R/equivalence_test.R
+++ b/R/equivalence_test.R
@@ -73,7 +73,7 @@
 #'   [`plot()`-method](https://easystats.github.io/see/articles/bayestestR.html)
 #'   to visualize the results from the equivalence-test (for models only).
 #'
-#' @examplesIf all(insight::check_if_installed(c("rstanarm", "brms", "emmeans", "BayesFactor"), quietly = TRUE))
+#' @examplesIf all(insight::check_if_installed(c("rstanarm", "brms", "emmeans", "BayesFactor", "see"), quietly = TRUE))
 #' library(bayestestR)
 #'
 #' equivalence_test(x = rnorm(1000, 0, 0.01), range = c(-0.1, 0.1))

--- a/R/estimate_density.R
+++ b/R/estimate_density.R
@@ -24,7 +24,8 @@
 #' @param by Optional character vector. If not `NULL` and input is a data frame,
 #' density estimation is performed for each group (subsets) indicated by `by`.
 #' See examples.
-#' @param at Deprecated in favour of `by`.
+#'
+#' @inheritSection hdi Model components
 #'
 #' @note There is also a [`plot()`-method](https://easystats.github.io/see/articles/bayestestR.html) implemented in the \href{https://easystats.github.io/see/}{\pkg{see}-package}.
 #'
@@ -172,17 +173,7 @@ estimate_density.numeric <- function(x,
                                      bw = "SJ",
                                      ci = NULL,
                                      by = NULL,
-                                     at = NULL,
                                      ...) {
-  # TODO remove deprecation warning
-  # Sanity
-  if (!is.null(at)) {
-    insight::format_warning(
-      "The `at` argument is deprecated and might be removed in a future update. Please replace by `by`."
-    )
-    by <- at
-  }
-
   if (!is.null(by)) {
     if (length(by) == 1) {
       insight::format_error(paste0(
@@ -231,7 +222,6 @@ estimate_density.data.frame <- function(x,
                                         ci = NULL,
                                         select = NULL,
                                         by = NULL,
-                                        at = NULL,
                                         rvar_col = NULL,
                                         ...) {
   x_rvar <- .possibly_extract_rvar_col(x, rvar_col)
@@ -250,15 +240,6 @@ estimate_density.data.frame <- function(x,
     return(out)
   }
 
-
-  # Sanity
-  if (!is.null(at)) {
-    insight::format_warning(paste0(
-      "The `at` argument is deprecated and might be removed in a future update.",
-      " Please replace by `by`."
-    ))
-    by <- at
-  }
 
   if (is.null(by)) {
     # No grouping -------------------
@@ -311,16 +292,7 @@ estimate_density.draws <- function(x,
                                    ci = NULL,
                                    select = NULL,
                                    by = NULL,
-                                   at = NULL,
                                    ...) {
-  if (!is.null(at)) {
-    insight::format_warning(paste0(
-      "The `at` argument is deprecated and might be removed in a future update.",
-      " Please replace by `by`."
-    ))
-    by <- at
-  }
-
   estimate_density(
     .posterior_draws_to_df(x),
     method = method,
@@ -436,15 +408,17 @@ estimate_density.stanreg <- function(x,
                                      extend = FALSE,
                                      extend_scale = 0.1,
                                      bw = "SJ",
-                                     effects = c("fixed", "random", "all"),
-                                     component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
+                                     effects = "fixed",
+                                     component = "location",
                                      parameters = NULL,
                                      ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   out <- estimate_density(
-    insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
+    insight::get_parameters(
+      x,
+      effects = effects,
+      component = component,
+      parameters = parameters
+    ),
     method = method,
     precision = precision,
     extend = extend,
@@ -465,6 +439,7 @@ estimate_density.stanfit <- estimate_density.stanreg
 estimate_density.blavaan <- estimate_density.stanreg
 
 
+#' @rdname estimate_density
 #' @export
 estimate_density.brmsfit <- function(x,
                                      method = "kernel",
@@ -472,15 +447,17 @@ estimate_density.brmsfit <- function(x,
                                      extend = FALSE,
                                      extend_scale = 0.1,
                                      bw = "SJ",
-                                     effects = c("fixed", "random", "all"),
-                                     component = c("conditional", "zi", "zero_inflated", "all"),
+                                     effects = "fixed",
+                                     component = "conditional",
                                      parameters = NULL,
                                      ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   out <- estimate_density(
-    insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
+    insight::get_parameters(
+      x,
+      effects = effects,
+      component = component,
+      parameters = parameters
+    ),
     method = method,
     precision = precision,
     extend = extend,
@@ -568,10 +545,9 @@ estimate_density.bamlss <- function(x,
                                     extend = FALSE,
                                     extend_scale = 0.1,
                                     bw = "SJ",
-                                    component = c("all", "conditional", "location"),
+                                    component = "all",
                                     parameters = NULL,
                                     ...) {
-  component <- match.arg(component)
   out <- estimate_density(
     insight::get_parameters(x, component = component, parameters = parameters),
     method = method,

--- a/R/eti.R
+++ b/R/eti.R
@@ -12,6 +12,8 @@
 #' @inherit hdi seealso
 #' @family ci
 #'
+#' @inheritSection hdi Model components
+#'
 #' @examplesIf require("rstanarm") && require("emmeans") && require("brms") && require("BayesFactor")
 #' library(bayestestR)
 #'
@@ -121,8 +123,7 @@ eti.mcmc <- function(x, ci = 0.95, verbose = TRUE, ...) {
 
 
 #' @export
-eti.bamlss <- function(x, ci = 0.95, component = c("all", "conditional", "location"), verbose = TRUE, ...) {
-  component <- match.arg(component)
+eti.bamlss <- function(x, ci = 0.95, component = "all", verbose = TRUE, ...) {
   d <- insight::get_parameters(x, component = component)
   dat <- .compute_interval_dataframe(x = d, ci = ci, verbose = verbose, fun = "eti")
   attr(dat, "data") <- insight::safe_deparse_symbol(substitute(x))
@@ -155,11 +156,10 @@ eti.BGGM <- eti.bcplm
 #' @export
 eti.sim.merMod <- function(x,
                            ci = 0.95,
-                           effects = c("fixed", "random", "all"),
+                           effects = "fixed",
                            parameters = NULL,
                            verbose = TRUE,
                            ...) {
-  effects <- match.arg(effects)
   dat <- .compute_interval_simMerMod(
     x = x,
     ci = ci,
@@ -176,7 +176,13 @@ eti.sim.merMod <- function(x,
 
 #' @export
 eti.sim <- function(x, ci = 0.95, parameters = NULL, verbose = TRUE, ...) {
-  dat <- .compute_interval_sim(x = x, ci = ci, parameters = parameters, verbose = verbose, fun = "eti")
+  dat <- .compute_interval_sim(
+    x = x,
+    ci = ci,
+    parameters = parameters,
+    verbose = verbose,
+    fun = "eti"
+  )
   out <- dat$result
   attr(out, "data") <- dat$data
   out
@@ -195,6 +201,7 @@ eti.emmGrid <- function(x, ci = 0.95, verbose = TRUE, ...) {
 #' @export
 eti.emm_list <- eti.emmGrid
 
+
 #' @export
 eti.slopes <- function(x, ci = 0.95, verbose = TRUE, ...) {
   xrvar <- .get_marginaleffects_draws(x)
@@ -210,17 +217,23 @@ eti.comparisons <- eti.slopes
 #' @export
 eti.predictions <- eti.slopes
 
-#' @rdname eti
-#' @export
-eti.stanreg <- function(x, ci = 0.95, effects = c("fixed", "random", "all"),
-                        component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
-                        parameters = NULL, verbose = TRUE, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
 
+#' @export
+eti.stanreg <- function(x,
+                        ci = 0.95,
+                        effects = "fixed",
+                        component = "location",
+                        parameters = NULL,
+                        verbose = TRUE,
+                        ...) {
   out <- .prepare_output(
     eti(
-      insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
+      insight::get_parameters(
+        x,
+        effects = effects,
+        component = component,
+        parameters = parameters
+      ),
       ci = ci,
       verbose = verbose,
       ...
@@ -234,7 +247,6 @@ eti.stanreg <- function(x, ci = 0.95, effects = c("fixed", "random", "all"),
   out
 }
 
-
 #' @export
 eti.stanfit <- eti.stanreg
 
@@ -244,15 +256,21 @@ eti.blavaan <- eti.stanreg
 
 #' @rdname eti
 #' @export
-eti.brmsfit <- function(x, ci = 0.95, effects = c("fixed", "random", "all"),
-                        component = c("conditional", "zi", "zero_inflated", "all"),
-                        parameters = NULL, verbose = TRUE, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
+eti.brmsfit <- function(x,
+                        ci = 0.95,
+                        effects = "fixed",
+                        component = "conditional",
+                        parameters = NULL,
+                        verbose = TRUE,
+                        ...) {
   out <- .prepare_output(
     eti(
-      insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
+      insight::get_parameters(
+        x,
+        effects = effects,
+        component = component,
+        parameters = parameters
+      ),
       ci = ci,
       verbose = verbose,
       ...

--- a/R/hdi.R
+++ b/R/hdi.R
@@ -285,12 +285,12 @@ hdi.BGGM <- hdi.bcplm
 #' @export
 hdi.sim.merMod <- function(x,
                            ci = 0.95,
-                           effects = c("fixed", "random", "all"),
+                           effects = "fixed",
                            parameters = NULL,
                            verbose = TRUE,
                            ...) {
   ci_fun <- .check_ci_fun(list(...))
-  effects <- match.arg(effects)
+
   dat <- .compute_interval_simMerMod(
     x = x,
     ci = ci,
@@ -349,17 +349,14 @@ hdi.comparisons <- hdi.slopes
 hdi.predictions <- hdi.slopes
 
 
-#' @rdname hdi
 #' @export
 hdi.stanreg <- function(x,
                         ci = 0.95,
-                        effects = c("fixed", "random", "all"),
-                        component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
+                        effects = "fixed",
+                        component = "location",
                         parameters = NULL,
                         verbose = TRUE,
                         ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(
@@ -395,13 +392,11 @@ hdi.blavaan <- hdi.stanreg
 #' @export
 hdi.brmsfit <- function(x,
                         ci = 0.95,
-                        effects = c("fixed", "random", "all"),
-                        component = c("conditional", "zi", "zero_inflated", "all"),
+                        effects = "fixed",
+                        component = "conditional",
                         parameters = NULL,
                         verbose = TRUE,
                         ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(

--- a/R/hdi.R
+++ b/R/hdi.R
@@ -237,11 +237,10 @@ hdi.MCMCglmm <- function(x, ci = 0.95, verbose = TRUE, ...) {
 #' @export
 hdi.bamlss <- function(x,
                        ci = 0.95,
-                       component = c("all", "conditional", "location"),
+                       component = "all",
                        verbose = TRUE,
                        ...) {
   ci_fun <- .check_ci_fun(list(...))
-  component <- match.arg(component)
   d <- insight::get_parameters(x, component = component)
   dat <- .compute_interval_dataframe(x = d, ci = ci, verbose = verbose, fun = ci_fun)
   dat <- .add_clean_parameters_attribute(dat, x)

--- a/R/map_estimate.R
+++ b/R/map_estimate.R
@@ -11,6 +11,8 @@
 #' @inheritParams hdi
 #' @inheritParams estimate_density
 #'
+#' @inheritSection hdi Model components
+#'
 #' @return A numeric value if `x` is a vector. If `x` is a model-object,
 #' returns a data frame with following columns:
 #'
@@ -112,14 +114,21 @@ map_estimate.mcmc.list <- map_estimate.bayesQR
 }
 
 
-#' @rdname map_estimate
 #' @export
-map_estimate.stanreg <- function(x, precision = 2^10, method = "kernel", effects = c("fixed", "random", "all"), component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"), parameters = NULL, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
+map_estimate.stanreg <- function(x,
+                                 precision = 2^10,
+                                 method = "kernel",
+                                 effects = "fixed",
+                                 component = "location",
+                                 parameters = NULL,
+                                 ...) {
   .map_estimate_models(
-    x = insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
+    x = insight::get_parameters(
+      x,
+      effects = effects,
+      component = component,
+      parameters = parameters
+    ),
     precision = precision,
     method = method
   )
@@ -134,13 +143,22 @@ map_estimate.blavaan <- map_estimate.stanreg
 
 #' @rdname map_estimate
 #' @export
-map_estimate.brmsfit <- function(x, precision = 2^10, method = "kernel", effects = c("fixed", "random", "all"), component = c("conditional", "zi", "zero_inflated", "all"), parameters = NULL, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
+map_estimate.brmsfit <- function(x,
+                                 precision = 2^10,
+                                 method = "kernel",
+                                 effects = "fixed",
+                                 component = "conditional",
+                                 parameters = NULL,
+                                 ...) {
   .map_estimate_models(
-    x = insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
-    precision = precision, method = method
+    x = insight::get_parameters(
+      x,
+      effects = effects,
+      component = component,
+      parameters = parameters
+    ),
+    precision = precision,
+    method = method
   )
 }
 

--- a/R/mcse.R
+++ b/R/mcse.R
@@ -4,6 +4,7 @@
 #'
 #' @inheritParams effective_sample
 #'
+#' @inheritSection hdi Model components
 #'
 #' @details **Monte Carlo Standard Error (MCSE)** is another measure of
 #' accuracy of the chains. It is defined as standard deviation of the chains
@@ -30,14 +31,11 @@ mcse <- function(model, ...) {
 
 #' @export
 mcse.brmsfit <- function(model,
-                         effects = c("fixed", "random", "all"),
-                         component = c("conditional", "zi", "zero_inflated", "all"),
+                         effects = "fixed",
+                         component = "conditional",
                          parameters = NULL,
                          ...) {
   # check arguments
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   params <- insight::get_parameters(
     model,
     effects = effects,
@@ -59,14 +57,10 @@ mcse.brmsfit <- function(model,
 #' @rdname mcse
 #' @export
 mcse.stanreg <- function(model,
-                         effects = c("fixed", "random", "all"),
-                         component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
+                         effects = "fixed",
+                         component = "location",
                          parameters = NULL,
                          ...) {
-  # check arguments
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   params <- insight::get_parameters(
     model,
     effects = effects,

--- a/R/mediation.R
+++ b/R/mediation.R
@@ -139,7 +139,6 @@ mediation.brmsfit <- function(model,
 }
 
 
-#' @rdname mediation
 #' @export
 mediation.stanmvreg <- function(model, treatment, mediator, response = NULL, centrality = "median", ci = 0.95, method = "ETI", ...) {
   .mediation(

--- a/R/p_direction.R
+++ b/R/p_direction.R
@@ -21,6 +21,8 @@
 #' data frame is assumed to represent draws from a posterior distribution.
 #' @inheritParams hdi
 #'
+#' @inheritSection hdi Model components
+#'
 #' @section What is the *pd*?:
 #'
 #' The Probability of Direction (pd) is an index of effect existence, representing
@@ -284,7 +286,6 @@ p_direction.draws <- function(x,
 p_direction.rvar <- p_direction.draws
 
 
-#' @rdname p_direction
 #' @export
 p_direction.MCMCglmm <- function(x,
                                  method = "direct",
@@ -325,13 +326,27 @@ p_direction.mcmc <- function(x,
 
 #' @export
 p_direction.BGGM <- function(x, method = "direct", null = 0, as_p = FALSE, remove_na = TRUE, ...) {
-  p_direction(as.data.frame(x), method = method, null = null, as_p = as_p, remove_na = remove_na, ...)
+  p_direction(
+    as.data.frame(x),
+    method = method,
+    null = null,
+    as_p = as_p,
+    remove_na = remove_na,
+    ...
+  )
 }
 
 
 #' @export
 p_direction.bcplm <- function(x, method = "direct", null = 0, as_p = FALSE, remove_na = TRUE, ...) {
-  p_direction(insight::get_parameters(x), method = method, null = null, as_p = as_p, remove_na = remove_na, ...)
+  p_direction(
+    insight::get_parameters(x),
+    method = method,
+    null = null,
+    as_p = as_p,
+    remove_na = remove_na,
+    ...
+  )
 }
 
 #' @export
@@ -350,9 +365,8 @@ p_direction.bamlss <- function(x,
                                null = 0,
                                as_p = FALSE,
                                remove_na = TRUE,
-                               component = c("all", "conditional", "location"),
+                               component = "all",
                                ...) {
-  component <- match.arg(component)
   out <- p_direction(
     insight::get_parameters(x, component = component),
     method = method,
@@ -366,11 +380,22 @@ p_direction.bamlss <- function(x,
 }
 
 
-#' @rdname p_direction
 #' @export
-p_direction.emmGrid <- function(x, method = "direct", null = 0, as_p = FALSE, remove_na = TRUE, ...) {
+p_direction.emmGrid <- function(x,
+                                method = "direct",
+                                null = 0,
+                                as_p = FALSE,
+                                remove_na = TRUE,
+                                ...) {
   xdf <- insight::get_parameters(x)
-  out <- p_direction(xdf, method = method, null = null, as_p = as_p, remove_na = remove_na, ...)
+  out <- p_direction(
+    xdf,
+    method = method,
+    null = null,
+    as_p = as_p,
+    remove_na = remove_na,
+    ...
+  )
   out <- .append_datagrid(out, x)
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   out
@@ -380,11 +405,23 @@ p_direction.emmGrid <- function(x, method = "direct", null = 0, as_p = FALSE, re
 #' @export
 p_direction.emm_list <- p_direction.emmGrid
 
-#' @rdname p_direction
+
 #' @export
-p_direction.slopes <- function(x, method = "direct", null = 0, as_p = FALSE, remove_na = TRUE, ...) {
+p_direction.slopes <- function(x,
+                               method = "direct",
+                               null = 0,
+                               as_p = FALSE,
+                               remove_na = TRUE,
+                               ...) {
   xrvar <- .get_marginaleffects_draws(x)
-  out <- p_direction(xrvar, method = method, null = null, as_p = as_p, remove_na = remove_na, ...)
+  out <- p_direction(
+    xrvar,
+    method = method,
+    null = null,
+    as_p = as_p,
+    remove_na = remove_na,
+    ...
+  )
   out <- .append_datagrid(out, x)
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   out
@@ -425,15 +462,13 @@ p_direction.predictions <- p_direction.slopes
 
 #' @export
 p_direction.sim.merMod <- function(x,
-                                   effects = c("fixed", "random", "all"),
+                                   effects = "fixed",
                                    parameters = NULL,
                                    method = "direct",
                                    null = 0,
                                    as_p = FALSE,
                                    remove_na = TRUE,
                                    ...) {
-  effects <- match.arg(effects)
-
   out <- .p_direction_models(
     x = x,
     effects = effects,
@@ -445,7 +480,11 @@ p_direction.sim.merMod <- function(x,
     remove_na = remove_na,
     ...
   )
-  attr(out, "data") <- insight::get_parameters(x, effects = effects, parameters = parameters)
+  attr(out, "data") <- insight::get_parameters(
+    x,
+    effects = effects,
+    parameters = parameters
+  )
   out
 }
 
@@ -474,19 +513,16 @@ p_direction.sim <- function(x,
 }
 
 
-#' @rdname p_direction
 #' @export
 p_direction.stanreg <- function(x,
-                                effects = c("fixed", "random", "all"),
-                                component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
+                                effects = "fixed",
+                                component = "location",
                                 parameters = NULL,
                                 method = "direct",
                                 null = 0,
                                 as_p = FALSE,
                                 remove_na = TRUE,
                                 ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(
@@ -524,16 +560,14 @@ p_direction.blavaan <- p_direction.stanreg
 #' @rdname p_direction
 #' @export
 p_direction.brmsfit <- function(x,
-                                effects = c("fixed", "random", "all"),
-                                component = c("conditional", "zi", "zero_inflated", "all"),
+                                effects = "fixed",
+                                component = "conditional",
                                 parameters = NULL,
                                 method = "direct",
                                 null = 0,
                                 as_p = FALSE,
                                 remove_na = TRUE,
                                 ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(
@@ -561,7 +595,6 @@ p_direction.brmsfit <- function(x,
 }
 
 
-#' @rdname p_direction
 #' @export
 p_direction.BFBayesFactor <- function(x,
                                       method = "direct",

--- a/R/p_map.R
+++ b/R/p_map.R
@@ -22,6 +22,8 @@
 #' @inheritParams density_at
 #' @inheritParams pd
 #'
+#' @inheritSection hdi Model components
+#'
 #' @examplesIf require("rstanarm") && require("emmeans") && require("brms") && require("BayesFactor")
 #' library(bayestestR)
 #'
@@ -214,7 +216,12 @@ p_map.predictions <- p_map.slopes
 
 
 #' @export
-p_map.mcmc <- function(x, null = 0, precision = 2^10, method = "kernel", parameters = NULL, ...) {
+p_map.mcmc <- function(x,
+                       null = 0,
+                       precision = 2^10,
+                       method = "kernel",
+                       parameters = NULL,
+                       ...) {
   out <- .p_map_models(
     x = x,
     null = null,
@@ -245,9 +252,13 @@ p_map.BGGM <- p_map.mcmc
 
 
 #' @export
-p_map.bamlss <- function(x, null = 0, precision = 2^10, method = "kernel",
-                         component = c("all", "conditional", "location"), parameters = NULL, ...) {
-  component <- match.arg(component)
+p_map.bamlss <- function(x,
+                         null = 0,
+                         precision = 2^10,
+                         method = "kernel",
+                         component = "all",
+                         parameters = NULL,
+                         ...) {
   out <- .p_map_models(
     x = x,
     null = null,
@@ -266,10 +277,13 @@ p_map.bamlss <- function(x, null = 0, precision = 2^10, method = "kernel",
 
 
 #' @export
-p_map.sim.merMod <- function(x, null = 0, precision = 2^10, method = "kernel",
-                             effects = c("fixed", "random", "all"), parameters = NULL, ...) {
-  effects <- match.arg(effects)
-
+p_map.sim.merMod <- function(x,
+                             null = 0,
+                             precision = 2^10,
+                             method = "kernel",
+                             effects = "fixed",
+                             parameters = NULL,
+                             ...) {
   out <- .p_map_models(
     x = x,
     null = null,
@@ -281,7 +295,11 @@ p_map.sim.merMod <- function(x, null = 0, precision = 2^10, method = "kernel",
     ...
   )
 
-  attr(out, "data") <- insight::get_parameters(x, effects = effects, parameters = parameters)
+  attr(out, "data") <- insight::get_parameters(
+    x,
+    effects = effects,
+    parameters = parameters
+  )
   out
 }
 
@@ -305,14 +323,15 @@ p_map.sim <- function(x, null = 0, precision = 2^10, method = "kernel",
 }
 
 
-#' @rdname p_map
 #' @export
-p_map.stanreg <- function(x, null = 0, precision = 2^10, method = "kernel",
-                          effects = c("fixed", "random", "all"),
-                          component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
-                          parameters = NULL, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+p_map.stanreg <- function(x,
+                          null = 0,
+                          precision = 2^10,
+                          method = "kernel",
+                          effects = "fixed",
+                          component = "location",
+                          parameters = NULL,
+                          ...) {
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(
@@ -347,12 +366,14 @@ p_map.blavaan <- p_map.stanreg
 
 #' @rdname p_map
 #' @export
-p_map.brmsfit <- function(x, null = 0, precision = 2^10, method = "kernel",
-                          effects = c("fixed", "random", "all"),
-                          component = c("conditional", "zi", "zero_inflated", "all"),
-                          parameters = NULL, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+p_map.brmsfit <- function(x,
+                          null = 0,
+                          precision = 2^10,
+                          method = "kernel",
+                          effects = "fixed",
+                          component = "conditional",
+                          parameters = NULL,
+                          ...) {
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(

--- a/R/p_rope.R
+++ b/R/p_rope.R
@@ -4,6 +4,8 @@
 #'
 #' @inheritParams rope
 #'
+#' @inheritSection hdi Model components
+#'
 #' @examples
 #' library(bayestestR)
 #'
@@ -104,20 +106,11 @@ p_rope.BFBayesFactor <- p_rope.numeric
 p_rope.MCMCglmm <- p_rope.numeric
 
 
-#' @rdname p_rope
 #' @export
 p_rope.stanreg <- function(x,
                            range = "default",
-                           effects = c("fixed", "random", "all"),
-                           component = c(
-                             "location",
-                             "all",
-                             "conditional",
-                             "smooth_terms",
-                             "sigma",
-                             "distributional",
-                             "auxiliary"
-                           ),
+                           effects = "fixed",
+                           component = "location",
                            parameters = NULL,
                            verbose = TRUE,
                            ...) {
@@ -147,8 +140,8 @@ p_rope.blavaan <- p_rope.stanreg
 #' @export
 p_rope.brmsfit <- function(x,
                            range = "default",
-                           effects = c("fixed", "random", "all"),
-                           component = c("conditional", "zi", "zero_inflated", "all"),
+                           effects = "fixed",
+                           component = "conditional",
                            parameters = NULL,
                            verbose = TRUE,
                            ...) {
@@ -182,11 +175,10 @@ p_rope.sim <- function(x, range = "default", parameters = NULL, verbose = TRUE, 
 #' @export
 p_rope.bamlss <- function(x,
                           range = "default",
-                          component = c("all", "conditional", "location"),
+                          component = "all",
                           parameters = NULL,
                           verbose = TRUE,
                           ...) {
-  component <- match.arg(component)
   out <- .p_rope(rope(
     x,
     range = range,
@@ -204,7 +196,14 @@ p_rope.bamlss <- function(x,
 
 #' @export
 p_rope.mcmc <- function(x, range = "default", parameters = NULL, verbose = TRUE, ...) {
-  out <- .p_rope(rope(x, range = range, ci = 1, parameters = parameters, verbose = verbose, ...))
+  out <- .p_rope(rope(
+    x,
+    range = range,
+    ci = 1,
+    parameters = parameters,
+    verbose = verbose,
+    ...
+  ))
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   out
 }

--- a/R/p_significance.R
+++ b/R/p_significance.R
@@ -23,6 +23,8 @@
 #' @inheritParams rope
 #' @inheritParams hdi
 #'
+#' @inheritSection hdi Model components
+#'
 #' @return Values between 0 and 1 corresponding to the probability of practical significance (ps).
 #'
 #' @details `p_significance()` returns the proportion of a probability
@@ -280,18 +282,20 @@ p_significance.comparisons <- p_significance.slopes
 p_significance.predictions <- p_significance.slopes
 
 
-#' @rdname p_significance
 #' @export
 p_significance.stanreg <- function(x,
                                    threshold = "default",
-                                   effects = c("fixed", "random", "all"),
-                                   component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"), # nolint
+                                   effects = "fixed",
+                                   component = "location",
                                    parameters = NULL,
                                    verbose = TRUE,
                                    ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-  params <- insight::get_parameters(x, effects = effects, component = component, parameters = parameters)
+  params <- insight::get_parameters(
+    x,
+    effects = effects,
+    component = component,
+    parameters = parameters
+  )
 
   threshold <- .select_threshold_ps(
     model = x,
@@ -323,14 +327,17 @@ p_significance.blavaan <- p_significance.stanreg
 #' @export
 p_significance.brmsfit <- function(x,
                                    threshold = "default",
-                                   effects = c("fixed", "random", "all"),
-                                   component = c("conditional", "zi", "zero_inflated", "all"),
+                                   effects = "fixed",
+                                   component = "conditional",
                                    parameters = NULL,
                                    verbose = TRUE,
                                    ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-  params <- insight::get_parameters(x, effects = effects, component = component, parameters = parameters)
+  params <- insight::get_parameters(
+    x,
+    effects = effects,
+    component = component,
+    parameters = parameters
+  )
 
   threshold <- .select_threshold_ps(
     model = x,
@@ -351,6 +358,7 @@ p_significance.brmsfit <- function(x,
   out
 }
 
+
 .p_significance <- function(x, threshold, ...) {
   if (length(threshold) == 1) {
     psig <- max(
@@ -370,6 +378,7 @@ p_significance.brmsfit <- function(x,
 
   psig
 }
+
 
 # methods ---------------------------
 
@@ -426,6 +435,7 @@ as.double.p_significance <- as.numeric.p_significance
   }
 }
 
+
 #' @keywords internal
 .select_threshold_list <- function(model = NULL, threshold = "default", verbose = TRUE) {
   # If default
@@ -446,6 +456,8 @@ as.double.p_significance <- as.numeric.p_significance
   threshold
 }
 
+
+#' @keywords internal
 .check_list_range <- function(range, params, larger_two = FALSE) {
   # if we have named elements, complete list
   named_range <- names(range)

--- a/R/p_significance.R
+++ b/R/p_significance.R
@@ -229,8 +229,12 @@ p_significance.mcmc <- function(x, threshold = "default", ...) {
 
 
 #' @export
-p_significance.bamlss <- function(x, threshold = "default", component = c("all", "conditional", "location"), ...) {
-  out <- p_significance(insight::get_parameters(x, component = component), threshold = threshold, ...)
+p_significance.bamlss <- function(x, threshold = "default", component = "all", ...) {
+  out <- p_significance(
+    insight::get_parameters(x, component = component),
+    threshold = threshold,
+    ...
+  )
   out <- .add_clean_parameters_attribute(out, x)
   out
 }

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -15,6 +15,8 @@
 #' @param ... Additional arguments to be passed to or from methods.
 #' @inheritParams hdi
 #'
+#' @inheritSection hdi Model components
+#'
 #' @references Makowski, D., Ben-Shachar, M. S., Chen, S. H. A., and Lüdecke, D.
 #' (2019). *Indices of Effect Existence and Significance in the Bayesian Framework*.
 #' Frontiers in Psychology 2019;10:2767. \doi{10.3389/fpsyg.2019.02767}
@@ -218,9 +220,8 @@ point_estimate.BGGM <- point_estimate.bcplm
 point_estimate.bamlss <- function(x,
                                   centrality = "all",
                                   dispersion = FALSE,
-                                  component = c("conditional", "location", "all"),
+                                  component = "conditional",
                                   ...) {
-  component <- match.arg(component)
   out <- point_estimate(
     insight::get_parameters(x, component = component),
     centrality = centrality,
@@ -270,15 +271,28 @@ point_estimate.comparisons <- point_estimate.slopes
 #' @export
 point_estimate.predictions <- point_estimate.slopes
 
-#' @rdname point_estimate
 #' @export
-point_estimate.stanreg <- function(x, centrality = "all", dispersion = FALSE, effects = c("fixed", "random", "all"), component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"), parameters = NULL, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+point_estimate.stanreg <- function(x,
+                                   centrality = "all",
+                                   dispersion = FALSE,
+                                   effects = "fixed",
+                                   component = "location",
+                                   parameters = NULL,
+                                   ...) {
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(
-    point_estimate(insight::get_parameters(x, effects = effects, component = component, parameters = parameters), centrality = centrality, dispersion = dispersion, ...),
+    point_estimate(
+      insight::get_parameters(
+        x,
+        effects = effects,
+        component = component,
+        parameters = parameters
+      ),
+      centrality = centrality,
+      dispersion = dispersion,
+      ...
+    ),
     cleaned_parameters,
     inherits(x, "stanmvreg")
   )
@@ -300,13 +314,27 @@ point_estimate.blavaan <- point_estimate.stanreg
 
 #' @rdname point_estimate
 #' @export
-point_estimate.brmsfit <- function(x, centrality = "all", dispersion = FALSE, effects = c("fixed", "random", "all"), component = c("conditional", "zi", "zero_inflated", "all"), parameters = NULL, ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+point_estimate.brmsfit <- function(x,
+                                   centrality = "all",
+                                   dispersion = FALSE,
+                                   effects = "fixed",
+                                   component = "conditional",
+                                   parameters = NULL,
+                                   ...) {
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(
-    point_estimate(insight::get_parameters(x, effects = effects, component = component, parameters = parameters), centrality = centrality, dispersion = dispersion, ...),
+    point_estimate(
+      insight::get_parameters(
+        x,
+        effects = effects,
+        component = component,
+        parameters = parameters
+      ),
+      centrality = centrality,
+      dispersion = dispersion,
+      ...
+    ),
     cleaned_parameters
   )
 
@@ -320,9 +348,12 @@ point_estimate.brmsfit <- function(x, centrality = "all", dispersion = FALSE, ef
 
 
 #' @export
-point_estimate.sim.merMod <- function(x, centrality = "all", dispersion = FALSE, effects = c("fixed", "random", "all"), parameters = NULL, ...) {
-  effects <- match.arg(effects)
-
+point_estimate.sim.merMod <- function(x,
+                                      centrality = "all",
+                                      dispersion = FALSE,
+                                      effects = "fixed",
+                                      parameters = NULL,
+                                      ...) {
   out <- .point_estimate_models(
     x = x,
     effects = effects,
@@ -332,7 +363,11 @@ point_estimate.sim.merMod <- function(x, centrality = "all", dispersion = FALSE,
     dispersion = dispersion,
     ...
   )
-  attr(out, "data") <- insight::get_parameters(x, effects = effects, parameters = parameters)
+  attr(out, "data") <- insight::get_parameters(
+    x,
+    effects = effects,
+    parameters = parameters
+  )
   attr(out, "centrality") <- centrality
   out <- .add_clean_parameters_attribute(out, x)
   class(out) <- unique(c("point_estimate", "see_point_estimate", class(out)))
@@ -360,7 +395,6 @@ point_estimate.sim <- function(x, centrality = "all", dispersion = FALSE, parame
 }
 
 
-#' @rdname point_estimate
 #' @export
 point_estimate.BFBayesFactor <- function(x, centrality = "all", dispersion = FALSE, ...) {
   out <- point_estimate(insight::get_parameters(x), centrality = centrality, dispersion = dispersion, ...)

--- a/R/rope.R
+++ b/R/rope.R
@@ -596,12 +596,10 @@ rope.sim.merMod <- function(x,
                             range = "default",
                             ci = 0.95,
                             ci_method = "ETI",
-                            effects = c("fixed", "random", "all"),
+                            effects = "fixed",
                             parameters = NULL,
                             verbose = TRUE,
                             ...) {
-  effects <- match.arg(effects)
-
   if (all(range == "default")) {
     range <- rope_range(x, verbose = verbose)
   } else if (!is.list(range) && (!all(is.numeric(range)) || length(range) != 2)) {

--- a/R/rope.R
+++ b/R/rope.R
@@ -464,9 +464,6 @@ rope.stanreg <- function(x,
                          parameters = NULL,
                          verbose = TRUE,
                          ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   if (all(range == "default")) {
     range <- rope_range(x, verbose = verbose)
   } else if (!is.list(range) && (!all(is.numeric(range)) || length(range) != 2)) {

--- a/R/rope.R
+++ b/R/rope.R
@@ -132,7 +132,7 @@
 #' rope(model, ci = c(0.90, 0.95))
 #'
 #' model <- brms::brm(
-#'   brmsbrms::bf(brms::mvbind(mpg, disp) ~ wt + cyl) + brms::set_rescor(rescor = TRUE),
+#'   brms::bf(brms::mvbind(mpg, disp) ~ wt + cyl) + brms::set_rescor(rescor = TRUE),
 #'   data = mtcars,
 #'   refresh = 0
 #' )

--- a/R/rope.R
+++ b/R/rope.R
@@ -28,6 +28,8 @@
 #'
 #' @inheritParams hdi
 #'
+#' @inheritSection hdi Model components
+#'
 #' @section ROPE:
 #' Statistically, the probability of a posterior distribution of being
 #' different from 0 does not make much sense (the probability of a single value
@@ -173,7 +175,12 @@ rope.default <- function(x, ...) {
 
 #' @rdname rope
 #' @export
-rope.numeric <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
+rope.numeric <- function(x,
+                         range = "default",
+                         ci = 0.95,
+                         ci_method = "ETI",
+                         verbose = TRUE,
+                         ...) {
   if (all(range == "default")) {
     range <- c(-0.1, 0.1)
   } else if (!all(is.numeric(range)) || length(range) != 2) {
@@ -193,7 +200,10 @@ rope.numeric <- function(x, range = "default", ci = 0.95, ci_method = "ETI", ver
   }
 
   # Attributes
-  hdi_area <- cbind(CI = ci, data.frame(do.call(rbind, lapply(rope_values, attr, "HDI_area"))))
+  hdi_area <- cbind(
+    CI = ci,
+    data.frame(do.call(rbind, lapply(rope_values, attr, "HDI_area")))
+  )
   names(hdi_area) <- c("CI", "CI_low", "CI_high")
 
   attr(out, "HDI_area") <- hdi_area
@@ -228,7 +238,14 @@ rope.get_predicted <- function(x,
     }
     attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   } else {
-    out <- rope(as.numeric(x), range = range, ci = ci, ci_method = ci_method, verbose = verbose, ...)
+    out <- rope(
+      as.numeric(x),
+      range = range,
+      ci = ci,
+      ci_method = ci_method,
+      verbose = verbose,
+      ...
+    )
   }
   out
 }
@@ -237,7 +254,13 @@ rope.get_predicted <- function(x,
 #' @export
 #' @rdname rope
 #' @inheritParams p_direction
-rope.data.frame <- function(x, range = "default", ci = 0.95, ci_method = "ETI", rvar_col = NULL, verbose = TRUE, ...) {
+rope.data.frame <- function(x,
+                            range = "default",
+                            ci = 0.95,
+                            ci_method = "ETI",
+                            rvar_col = NULL,
+                            verbose = TRUE,
+                            ...) {
   obj_name <- insight::safe_deparse_symbol(substitute(x))
 
   x_rvar <- .possibly_extract_rvar_col(x, rvar_col)
@@ -271,8 +294,20 @@ rope.data.frame <- function(x, range = "default", ci = 0.95, ci_method = "ETI", 
 
 
 #' @export
-rope.draws <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
-  rope(.posterior_draws_to_df(x), range = range, ci = ci, ci_method = ci_method, verbose = verbose, ...)
+rope.draws <- function(x,
+                       range = "default",
+                       ci = 0.95,
+                       ci_method = "ETI",
+                       verbose = TRUE,
+                       ...) {
+  rope(
+    .posterior_draws_to_df(x),
+    range = range,
+    ci = ci,
+    ci_method = ci_method,
+    verbose = verbose,
+    ...
+  )
 }
 
 #' @export
@@ -280,7 +315,12 @@ rope.rvar <- rope.draws
 
 
 #' @export
-rope.emmGrid <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
+rope.emmGrid <- function(x,
+                         range = "default",
+                         ci = 0.95,
+                         ci_method = "ETI",
+                         verbose = TRUE,
+                         ...) {
   xdf <- insight::get_parameters(x)
   dat <- rope(xdf, range = range, ci = ci, ci_method = ci_method, verbose = verbose, ...)
   dat <- .append_datagrid(dat, x)
@@ -291,10 +331,23 @@ rope.emmGrid <- function(x, range = "default", ci = 0.95, ci_method = "ETI", ver
 #' @export
 rope.emm_list <- rope.emmGrid
 
+
 #' @export
-rope.slopes <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
+rope.slopes <- function(x,
+                        range = "default",
+                        ci = 0.95,
+                        ci_method = "ETI",
+                        verbose = TRUE,
+                        ...) {
   xrvar <- .get_marginaleffects_draws(x)
-  dat <- rope(xrvar, range = range, ci = ci, ci_method = ci_method, verbose = verbose, ...)
+  dat <- rope(
+    xrvar,
+    range = range,
+    ci = ci,
+    ci_method = ci_method,
+    verbose = verbose,
+    ...
+  )
   dat <- .append_datagrid(dat, x)
   attr(dat, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   dat
@@ -308,11 +361,23 @@ rope.predictions <- rope.slopes
 
 
 #' @export
-rope.BFBayesFactor <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
+rope.BFBayesFactor <- function(x,
+                               range = "default",
+                               ci = 0.95,
+                               ci_method = "ETI",
+                               verbose = TRUE,
+                               ...) {
   if (all(range == "default")) {
     range <- rope_range(x, verbose = verbose)
   }
-  out <- rope(insight::get_parameters(x), range = range, ci = ci, ci_method = ci_method, verbose = verbose, ...)
+  out <- rope(
+    insight::get_parameters(x),
+    range = range,
+    ci = ci,
+    ci_method = ci_method,
+    verbose = verbose,
+    ...
+  )
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   out
 }
@@ -322,7 +387,12 @@ rope.bamlss <- rope.BFBayesFactor
 
 
 #' @export
-rope.MCMCglmm <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
+rope.MCMCglmm <- function(x,
+                          range = "default",
+                          ci = 0.95,
+                          ci_method = "ETI",
+                          verbose = TRUE,
+                          ...) {
   nF <- x$Fixed$nfl
   out <- rope(
     as.data.frame(x$Sol[, 1:nF, drop = FALSE]),
@@ -338,8 +408,20 @@ rope.MCMCglmm <- function(x, range = "default", ci = 0.95, ci_method = "ETI", ve
 
 
 #' @export
-rope.mcmc <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
-  out <- rope(as.data.frame(x), range = range, ci = ci, ci_method = ci_method, verbose = verbose, ...)
+rope.mcmc <- function(x,
+                      range = "default",
+                      ci = 0.95,
+                      ci_method = "ETI",
+                      verbose = TRUE,
+                      ...) {
+  out <- rope(
+    as.data.frame(x),
+    range = range,
+    ci = ci,
+    ci_method = ci_method,
+    verbose = verbose,
+    ...
+  )
   attr(out, "object_name") <- NULL
   attr(out, "data") <- insight::safe_deparse_symbol(substitute(x))
   out
@@ -347,7 +429,12 @@ rope.mcmc <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbos
 
 
 #' @export
-rope.bcplm <- function(x, range = "default", ci = 0.95, ci_method = "ETI", verbose = TRUE, ...) {
+rope.bcplm <- function(x,
+                       range = "default",
+                       ci = 0.95,
+                       ci_method = "ETI",
+                       verbose = TRUE,
+                       ...) {
   out <- rope(insight::get_parameters(x), range = range, ci = ci, ci_method = ci_method, verbose = verbose, ...)
   attr(out, "object_name") <- NULL
   attr(out, "data") <- insight::safe_deparse_symbol(substitute(x))
@@ -367,36 +454,16 @@ rope.BGGM <- rope.bcplm
 rope.mcmc.list <- rope.bcplm
 
 
-#' @keywords internal
-.rope <- function(x, range = c(-0.1, 0.1), ci = 0.95, ci_method = "ETI", verbose = TRUE) {
-  ci_bounds <- ci(x, ci = ci, method = ci_method, verbose = verbose)
-
-  if (anyNA(ci_bounds)) {
-    rope_percentage <- NA
-  } else {
-    HDI_area <- x[x >= ci_bounds$CI_low & x <= ci_bounds$CI_high]
-    area_within <- HDI_area[HDI_area >= min(range) & HDI_area <= max(range)]
-    rope_percentage <- length(area_within) / length(HDI_area)
-  }
-
-
-  rope <- data.frame(
-    CI = ci,
-    ROPE_low = range[1],
-    ROPE_high = range[2],
-    ROPE_Percentage = rope_percentage
-  )
-
-  attr(rope, "HDI_area") <- c(ci_bounds$CI_low, ci_bounds$CI_high)
-  attr(rope, "CI_bounds") <- c(ci_bounds$CI_low, ci_bounds$CI_high)
-  class(rope) <- unique(c("rope", "see_rope", class(rope)))
-  rope
-}
-
-
-#' @rdname rope
 #' @export
-rope.stanreg <- function(x, range = "default", ci = 0.95, ci_method = "ETI", effects = c("fixed", "random", "all"), component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"), parameters = NULL, verbose = TRUE, ...) {
+rope.stanreg <- function(x,
+                         range = "default",
+                         ci = 0.95,
+                         ci_method = "ETI",
+                         effects = "fixed",
+                         component = "location",
+                         parameters = NULL,
+                         verbose = TRUE,
+                         ...) {
   effects <- match.arg(effects)
   component <- match.arg(component)
 
@@ -440,14 +507,11 @@ rope.brmsfit <- function(x,
                          range = "default",
                          ci = 0.95,
                          ci_method = "ETI",
-                         effects = c("fixed", "random", "all"),
-                         component = c("conditional", "zi", "zero_inflated", "all"),
+                         effects = "fixed",
+                         component = "conditional",
                          parameters = NULL,
                          verbose = TRUE,
                          ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   # check range argument
   if (all(range == "default")) {
     range <- rope_range(x, verbose = verbose)
@@ -482,7 +546,12 @@ rope.brmsfit <- function(x,
       dv,
       function(dv_item) {
         ret <- rope(
-          insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
+          insight::get_parameters(
+            x,
+            effects = effects,
+            component = component,
+            parameters = parameters
+          ),
           range = range[[dv_item]],
           ci = ci,
           ci_method = ci_method,
@@ -564,7 +633,10 @@ rope.sim.merMod <- function(x,
     tmp
   })
 
-  dat <- do.call(rbind, args = c(insight::compact_list(rope_list), make.row.names = FALSE))
+  dat <- do.call(
+    rbind,
+    args = c(insight::compact_list(rope_list), make.row.names = FALSE)
+  )
 
   dat <- switch(effects,
     fixed = .select_rows(dat, "Group", "fixed"),
@@ -592,7 +664,13 @@ rope.sim.merMod <- function(x,
 
 
 #' @export
-rope.sim <- function(x, range = "default", ci = 0.95, ci_method = "ETI", parameters = NULL, verbose = TRUE, ...) {
+rope.sim <- function(x,
+                     range = "default",
+                     ci = 0.95,
+                     ci_method = "ETI",
+                     parameters = NULL,
+                     verbose = TRUE,
+                     ...) {
   if (all(range == "default")) {
     range <- rope_range(x, verbose = verbose)
   } else if (!is.list(range) && (!all(is.numeric(range)) || length(range) != 2)) {
@@ -623,6 +701,36 @@ rope.sim <- function(x, range = "default", ci = 0.95, ci_method = "ETI", paramet
   attr(dat, "object_name") <- insight::safe_deparse_symbol(substitute(x))
 
   dat
+}
+
+
+# helper -------------------------------------------------------------------
+
+
+#' @keywords internal
+.rope <- function(x, range = c(-0.1, 0.1), ci = 0.95, ci_method = "ETI", verbose = TRUE) {
+  ci_bounds <- ci(x, ci = ci, method = ci_method, verbose = verbose)
+
+  if (anyNA(ci_bounds)) {
+    rope_percentage <- NA
+  } else {
+    HDI_area <- x[x >= ci_bounds$CI_low & x <= ci_bounds$CI_high]
+    area_within <- HDI_area[HDI_area >= min(range) & HDI_area <= max(range)]
+    rope_percentage <- length(area_within) / length(HDI_area)
+  }
+
+
+  rope <- data.frame(
+    CI = ci,
+    ROPE_low = range[1],
+    ROPE_high = range[2],
+    ROPE_Percentage = rope_percentage
+  )
+
+  attr(rope, "HDI_area") <- c(ci_bounds$CI_low, ci_bounds$CI_high)
+  attr(rope, "CI_bounds") <- c(ci_bounds$CI_low, ci_bounds$CI_high)
+  class(rope) <- unique(c("rope", "see_rope", class(rope)))
+  rope
 }
 
 

--- a/R/si.R
+++ b/R/si.R
@@ -113,17 +113,16 @@ si.numeric <- function(posterior, prior = NULL, BF = 1, verbose = TRUE, ...) {
   out
 }
 
+
 #' @rdname si
 #' @export
 si.stanreg <- function(posterior, prior = NULL,
                        BF = 1, verbose = TRUE,
-                       effects = c("fixed", "random", "all"),
-                       component = c("location", "conditional", "all", "smooth_terms", "sigma", "auxiliary", "distributional"),
+                       effects = "fixed",
+                       component = "location",
                        parameters = NULL,
                        ...) {
   cleaned_parameters <- insight::clean_parameters(posterior)
-  effects <- match.arg(effects)
-  component <- match.arg(component)
 
   samps <- .clean_priors_and_posteriors(posterior, prior,
     effects = effects, component = component,
@@ -146,17 +145,13 @@ si.stanreg <- function(posterior, prior = NULL,
   out
 }
 
-
-#' @rdname si
 #' @export
 si.brmsfit <- si.stanreg
 
-#' @rdname si
 #' @export
 si.blavaan <- si.stanreg
 
 
-#' @rdname si
 #' @export
 si.emmGrid <- function(posterior, prior = NULL,
                        BF = 1, verbose = TRUE, ...) {
@@ -188,7 +183,7 @@ si.predictions <- si.emmGrid
 
 
 #' @export
-si.stanfit <- function(posterior, prior = NULL, BF = 1, verbose = TRUE, effects = c("fixed", "random", "all"), ...) {
+si.stanfit <- function(posterior, prior = NULL, BF = 1, verbose = TRUE, effects = "fixed", ...) {
   out <- si(insight::get_parameters(posterior, effects = effects),
     prior = prior, BF = BF, verbose = verbose
   )

--- a/R/simulate_priors.R
+++ b/R/simulate_priors.R
@@ -27,15 +27,11 @@ simulate_prior <- function(model, n = 1000, ...) {
 #' @export
 simulate_prior.stanreg <- function(model,
                                    n = 1000,
-                                   effects = c("fixed", "random", "all"),
-                                   component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
+                                   effects = "fixed",
+                                   component = "location",
                                    parameters = NULL,
                                    verbose = TRUE,
                                    ...) {
-  # check arguments
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   priors <- insight::get_priors(
     model,
     effects = effects,
@@ -50,18 +46,16 @@ simulate_prior.stanreg <- function(model,
 #' @export
 simulate_prior.blavaan <- simulate_prior.stanreg
 
+
+#' @rdname simulate_prior
 #' @export
 simulate_prior.brmsfit <- function(model,
                                    n = 1000,
-                                   effects = c("fixed", "random", "all"),
-                                   component = c("conditional", "zi", "zero_inflated", "all"),
+                                   effects = "fixed",
+                                   component = "conditional",
                                    parameters = NULL,
                                    verbose = TRUE,
                                    ...) {
-  # check arguments
-  effects <- match.arg(effects)
-  component <- match.arg(component)
-
   priors <- insight::get_priors(
     model,
     effects = effects,

--- a/R/simulate_priors.R
+++ b/R/simulate_priors.R
@@ -4,6 +4,7 @@
 #'
 #' @inheritParams effective_sample
 #' @param n Size of the simulated prior distributions.
+#' @inheritParams hdi
 #'
 #' @seealso [`unupdate()`] for directly sampling from the prior
 #'   distribution (useful for complex priors and designs).

--- a/R/spi.R
+++ b/R/spi.R
@@ -109,10 +109,9 @@ spi.MCMCglmm <- function(x, ci = 0.95, verbose = TRUE, ...) {
 #' @export
 spi.bamlss <- function(x,
                        ci = 0.95,
-                       component = c("all", "conditional", "location"),
+                       component = "all",
                        verbose = TRUE,
                        ...) {
-  component <- match.arg(component)
   hdi(x, ci = ci, component = component, verbose = verbose, ci_method = "spi")
 }
 
@@ -140,12 +139,19 @@ spi.BGGM <- spi.mcmc
 #' @export
 spi.sim.merMod <- function(x,
                            ci = 0.95,
-                           effects = c("fixed", "random", "all"),
+                           effects = "fixed",
                            parameters = NULL,
                            verbose = TRUE,
                            ...) {
-  effects <- match.arg(effects)
-  hdi(x, ci = ci, effects = effects, parameters = parameters, verbose = verbose, ci_method = "spi", ...)
+  hdi(
+    x,
+    ci = ci,
+    effects = effects,
+    parameters = parameters,
+    verbose = verbose,
+    ci_method = "spi",
+    ...
+  )
 }
 
 #' @export
@@ -180,17 +186,15 @@ spi.comparisons <- spi.slopes
 #' @export
 spi.predictions <- spi.slopes
 
-#' @rdname spi
+
 #' @export
 spi.stanreg <- function(x,
                         ci = 0.95,
-                        effects = c("fixed", "random", "all"),
-                        component = c("location", "all", "conditional", "smooth_terms", "sigma", "distributional", "auxiliary"),
+                        effects = "fixed",
+                        component = "location",
                         parameters = NULL,
                         verbose = TRUE,
                         ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(
@@ -226,13 +230,11 @@ spi.blavaan <- spi.stanreg
 #' @export
 spi.brmsfit <- function(x,
                         ci = 0.95,
-                        effects = c("fixed", "random", "all"),
-                        component = c("conditional", "zi", "zero_inflated", "all"),
+                        effects = "fixed",
+                        component = "conditional",
                         parameters = NULL,
                         verbose = TRUE,
                         ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
   cleaned_parameters <- insight::clean_parameters(x)
 
   out <- .prepare_output(

--- a/R/unupdate.R
+++ b/R/unupdate.R
@@ -83,6 +83,7 @@ unupdate.brmsfit <- function(model, verbose = TRUE, ...) {
 }
 
 
+#' @rdname unupdate
 #' @export
 unupdate.brmsfit_multiple <- function(model,
                                       verbose = TRUE,

--- a/R/unupdate.R
+++ b/R/unupdate.R
@@ -23,7 +23,6 @@ unupdate <- function(model, verbose = TRUE, ...) {
 
 
 #' @export
-#' @rdname unupdate
 unupdate.stanreg <- function(model, verbose = TRUE, ...) {
   insight::check_if_installed("rstanarm")
 
@@ -51,8 +50,8 @@ unupdate.stanreg <- function(model, verbose = TRUE, ...) {
 }
 
 
-#' @export
 #' @rdname unupdate
+#' @export
 unupdate.brmsfit <- function(model, verbose = TRUE, ...) {
   insight::check_if_installed("brms")
 
@@ -85,7 +84,6 @@ unupdate.brmsfit <- function(model, verbose = TRUE, ...) {
 
 
 #' @export
-#' @rdname unupdate
 unupdate.brmsfit_multiple <- function(model,
                                       verbose = TRUE,
                                       newdata = NULL,
@@ -127,7 +125,6 @@ unupdate.brmsfit_multiple <- function(model,
 
 
 #' @export
-#' @rdname unupdate
 unupdate.blavaan <- function(model, verbose = TRUE, ...) {
   insight::check_if_installed("blavaan")
 

--- a/R/weighted_posteriors.R
+++ b/R/weighted_posteriors.R
@@ -205,6 +205,7 @@ weighted_posteriors.brmsfit <- weighted_posteriors.stanreg
 #' @export
 weighted_posteriors.blavaan <- weighted_posteriors.stanreg
 
+#' @rdname weighted_posteriors
 #' @export
 weighted_posteriors.BFBayesFactor <- function(...,
                                               prior_odds = NULL,

--- a/R/weighted_posteriors.R
+++ b/R/weighted_posteriors.R
@@ -171,12 +171,10 @@ weighted_posteriors.stanreg <- function(...,
                                         prior_odds = NULL,
                                         missing = 0,
                                         verbose = TRUE,
-                                        effects = c("fixed", "random", "all"),
-                                        component = c("conditional", "zi", "zero_inflated", "all"),
+                                        effects = "fixed",
+                                        component = "conditional",
                                         parameters = NULL) {
   Mods <- list(...)
-  effects <- match.arg(effects)
-  component <- match.arg(component)
 
   # Get Bayes factors
   BFMods <- bayesfactor_models(..., denominator = 1, verbose = verbose)
@@ -202,15 +200,12 @@ weighted_posteriors.stanreg <- function(...,
 }
 
 #' @export
-#' @rdname weighted_posteriors
 weighted_posteriors.brmsfit <- weighted_posteriors.stanreg
 
 #' @export
-#' @rdname weighted_posteriors
 weighted_posteriors.blavaan <- weighted_posteriors.stanreg
 
 #' @export
-#' @rdname weighted_posteriors
 weighted_posteriors.BFBayesFactor <- function(...,
                                               prior_odds = NULL,
                                               missing = 0,

--- a/man/bayesfactor.Rd
+++ b/man/bayesfactor.Rd
@@ -10,7 +10,7 @@ bayesfactor(
   direction = "two-sided",
   null = 0,
   hypothesis = NULL,
-  effects = c("fixed", "random", "all"),
+  effects = "fixed",
   verbose = TRUE,
   denominator = 1,
   match_models = FALSE,

--- a/man/bayesfactor_inclusion.Rd
+++ b/man/bayesfactor_inclusion.Rd
@@ -25,9 +25,8 @@ log(BF) for each effect (Use \code{as.numeric()} to extract the non-log Bayes
 factors; see examples).
 }
 \description{
-The \verb{bf_*} function is an alias of the main function.
-\cr \cr
-For more info, see \href{https://easystats.github.io/bayestestR/articles/bayes_factors.html}{the Bayes factors vignette}.
+The \verb{bf_*} function is an alias of the main function. For more info, see
+\href{https://easystats.github.io/bayestestR/articles/bayes_factors.html}{the Bayes factors vignette}.
 }
 \details{
 Inclusion Bayes factors answer the question: Are the observed data

--- a/man/bayesfactor_models.Rd
+++ b/man/bayesfactor_models.Rd
@@ -48,9 +48,8 @@ random effects) and their \code{log(BF)}s  (Use \code{as.numeric()} to extract t
 non-log Bayes factors; see examples), that prints nicely.
 }
 \description{
-This function computes or extracts Bayes factors from fitted models.
-\cr \cr
-The \verb{bf_*} function is an alias of the main function.
+This function computes or extracts Bayes factors from fitted
+models. The \verb{bf_*} function is an alias of the main function.
 }
 \details{
 If the passed models are supported by \strong{insight} the DV of all models will

--- a/man/bayesfactor_parameters.Rd
+++ b/man/bayesfactor_parameters.Rd
@@ -9,8 +9,6 @@
 \alias{bf_rope}
 \alias{bayesfactor_parameters.numeric}
 \alias{bayesfactor_parameters.stanreg}
-\alias{bayesfactor_parameters.brmsfit}
-\alias{bayesfactor_parameters.blavaan}
 \alias{bayesfactor_parameters.data.frame}
 \title{Bayes Factors (BF) for a Single Parameter}
 \usage{
@@ -82,32 +80,9 @@ bf_rope(
   prior = NULL,
   direction = "two-sided",
   null = 0,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "location", "smooth_terms", "sigma", "zi",
-    "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
-  ...,
-  verbose = TRUE
-)
-
-\method{bayesfactor_parameters}{brmsfit}(
-  posterior,
-  prior = NULL,
-  direction = "two-sided",
-  null = 0,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "location", "smooth_terms", "sigma", "zi",
-    "zero_inflated", "all"),
-  parameters = NULL,
-  ...,
-  verbose = TRUE
-)
-
-\method{bayesfactor_parameters}{blavaan}(
-  posterior,
-  prior = NULL,
-  direction = "two-sided",
-  null = 0,
   ...,
   verbose = TRUE
 )
@@ -278,6 +253,35 @@ null, at which one convention is that a Bayes factor greater than 3 can be
 considered as "substantial" evidence against the null (and vice versa, a
 Bayes factor smaller than 1/3 indicates substantial evidence in favor of the
 null-model) (\cite{Wetzels et al. 2011}).
+}
+
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
 }
 
 \examples{

--- a/man/bayesfactor_restricted.Rd
+++ b/man/bayesfactor_restricted.Rd
@@ -20,8 +20,8 @@ bf_restricted(posterior, ...)
   hypothesis,
   prior = NULL,
   verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   ...
 )
 
@@ -30,8 +30,8 @@ bf_restricted(posterior, ...)
   hypothesis,
   prior = NULL,
   verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   ...
 )
 

--- a/man/bci.Rd
+++ b/man/bci.Rd
@@ -5,14 +5,7 @@
 \alias{bcai}
 \alias{bci.numeric}
 \alias{bci.data.frame}
-\alias{bci.MCMCglmm}
-\alias{bci.sim.merMod}
-\alias{bci.sim}
-\alias{bci.emmGrid}
-\alias{bci.slopes}
-\alias{bci.stanreg}
 \alias{bci.brmsfit}
-\alias{bci.BFBayesFactor}
 \alias{bci.get_predicted}
 \title{Bias Corrected and Accelerated Interval (BCa)}
 \usage{
@@ -24,45 +17,15 @@ bcai(x, ...)
 
 \method{bci}{data.frame}(x, ci = 0.95, rvar_col = NULL, verbose = TRUE, ...)
 
-\method{bci}{MCMCglmm}(x, ci = 0.95, verbose = TRUE, ...)
-
-\method{bci}{sim.merMod}(
-  x,
-  ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
-\method{bci}{sim}(x, ci = 0.95, parameters = NULL, verbose = TRUE, ...)
-
-\method{bci}{emmGrid}(x, ci = 0.95, verbose = TRUE, ...)
-
-\method{bci}{slopes}(x, ci = 0.95, verbose = TRUE, ...)
-
-\method{bci}{stanreg}(
-  x,
-  ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{bci}{brmsfit}(
   x,
   ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...
 )
-
-\method{bci}{BFBayesFactor}(x, ci = 0.95, verbose = TRUE, ...)
 
 \method{bci}{get_predicted}(x, ci = 0.95, use_iterations = FALSE, verbose = TRUE, ...)
 }
@@ -87,12 +50,6 @@ frame to be processed. See example in \code{\link[=p_direction]{p_direction()}}.
 random effects (\code{"random"}) or both ("\verb{all"}) be returned? Only applies to
 mixed models. May be abbreviated.}
 
-\item{parameters}{Regular expression pattern that describes the parameters
-that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
-filtered by default, so only parameters that typically appear in the
-\code{summary()} are returned. Use \code{parameters} to select specific parameters
-for the output.}
-
 \item{component}{Which type of parameters to return, such as parameters for
 the conditional model, the zero-inflated part of the model, the dispersion
 term, etc. See details in section \emph{Model Components}. May be abbreviated.
@@ -109,6 +66,12 @@ but no auxiliary parameters).
 \code{sigma}, \code{dispersion}, \code{beta} or \code{precision} (and other auxiliary
 parameters) are returned.
 }}
+
+\item{parameters}{Regular expression pattern that describes the parameters
+that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
+filtered by default, so only parameters that typically appear in the
+\code{summary()} are returned. Use \code{parameters} to select specific parameters
+for the output.}
 
 \item{use_iterations}{Logical, if \code{TRUE} and \code{x} is a \code{get_predicted} object,
 (returned by \code{\link[insight:get_predicted]{insight::get_predicted()}}), the function is applied to the
@@ -176,6 +139,35 @@ to the transformed lower and higher bounds of the original distribution.
 On the contrary, applying transformations to the distribution will change
 the resulting HDI.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 posterior <- rnorm(1000)
 bci(posterior)

--- a/man/check_prior.Rd
+++ b/man/check_prior.Rd
@@ -2,9 +2,21 @@
 % Please edit documentation in R/check_prior.R
 \name{check_prior}
 \alias{check_prior}
+\alias{check_prior.brmsfit}
 \title{Check if Prior is Informative}
 \usage{
 check_prior(model, method = "gelman", simulate_priors = TRUE, ...)
+
+\method{check_prior}{brmsfit}(
+  model,
+  method = "gelman",
+  simulate_priors = TRUE,
+  effects = "fixed",
+  component = "conditional",
+  parameters = NULL,
+  verbose = TRUE,
+  ...
+)
 }
 \arguments{
 \item{model}{A \code{stanreg}, \code{stanfit}, \code{brmsfit}, \code{blavaan}, or \code{MCMCglmm} object.}
@@ -20,6 +32,35 @@ posterior falls within the \verb{95\%} HDI of the prior.}
 \code{\link[=unupdate]{unupdate()}} (slower, more accurate).}
 
 \item{...}{Currently not used.}
+
+\item{effects}{Should results for fixed effects (\code{"fixed"}, the default),
+random effects (\code{"random"}) or both ("\verb{all"}) be returned? Only applies to
+mixed models. May be abbreviated.}
+
+\item{component}{Which type of parameters to return, such as parameters for
+the conditional model, the zero-inflated part of the model, the dispersion
+term, etc. See details in section \emph{Model Components}. May be abbreviated.
+Note that the \emph{conditional} component also refers to the \emph{count} or \emph{mean}
+component - names may differ, depending on the modeling package. There are
+three convenient shortcuts (not applicable to \emph{all} model classes):
+\itemize{
+\item \code{component = "all"} returns all possible parameters.
+\item If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned (everything
+that are fixed or random effects - depending on the \code{effects} argument -
+but no auxiliary parameters).
+\item For \code{component = "distributional"} (or \code{"auxiliary"}), components like
+\code{sigma}, \code{dispersion}, \code{beta} or \code{precision} (and other auxiliary
+parameters) are returned.
+}}
+
+\item{parameters}{Regular expression pattern that describes the parameters
+that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
+filtered by default, so only parameters that typically appear in the
+\code{summary()} are returned. Use \code{parameters} to select specific parameters
+for the output.}
+
+\item{verbose}{Toggle off warnings.}
 }
 \value{
 A data frame with two columns: The parameter names and the quality

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -140,19 +140,19 @@ df <- data.frame(replicate(4, rnorm(100)))
 ci(df, method = "ETI", ci = c(0.80, 0.89, 0.95))
 ci(df, method = "HDI", ci = c(0.80, 0.89, 0.95))
 
-model <- suppressWarnings(
-  stan_glm(mpg ~ wt, data = mtcars, chains = 2, iter = 200, refresh = 0)
-)
+model <- suppressWarnings(rstanarm::stan_glm(
+  mpg ~ wt, data = mtcars, chains = 2, iter = 200, refresh = 0
+))
 ci(model, method = "ETI", ci = c(0.80, 0.89))
 ci(model, method = "HDI", ci = c(0.80, 0.89))
 \dontshow{\}) # examplesIf}
 \dontshow{if (require("BayesFactor", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-bf <- ttestBF(x = rnorm(100, 1, 1))
+bf <- BayesFactor::ttestBF(x = rnorm(100, 1, 1))
 ci(bf, method = "ETI")
 ci(bf, method = "HDI")
 \dontshow{\}) # examplesIf}
 \dontshow{if (require("emmeans", quietly = TRUE) && require("rstanarm", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-model <- emtrends(model, ~1, "wt", data = mtcars)
+model <- emmeans::emtrends(model, ~1, "wt", data = mtcars)
 ci(model, method = "ETI")
 ci(model, method = "HDI")
 \dontshow{\}) # examplesIf}

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -99,6 +99,35 @@ the data should not seem very surprising" (\emph{Gelman & Greenland 2019}).
 
 There is also a \href{https://easystats.github.io/see/articles/bayestestR.html}{\code{plot()}-method} implemented in the \href{https://easystats.github.io/see/}{\pkg{see}-package}.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -4,12 +4,7 @@
 \alias{ci}
 \alias{ci.numeric}
 \alias{ci.data.frame}
-\alias{ci.sim.merMod}
-\alias{ci.sim}
-\alias{ci.stanreg}
 \alias{ci.brmsfit}
-\alias{ci.BFBayesFactor}
-\alias{ci.MCMCglmm}
 \title{Confidence/Credible/Compatibility Interval (CI)}
 \usage{
 ci(x, ...)
@@ -18,46 +13,17 @@ ci(x, ...)
 
 \method{ci}{data.frame}(x, ci = 0.95, method = "ETI", BF = 1, rvar_col = NULL, verbose = TRUE, ...)
 
-\method{ci}{sim.merMod}(
-  x,
-  ci = 0.95,
-  method = "ETI",
-  effects = c("fixed", "random", "all"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
-\method{ci}{sim}(x, ci = 0.95, method = "ETI", parameters = NULL, verbose = TRUE, ...)
-
-\method{ci}{stanreg}(
-  x,
-  ci = 0.95,
-  method = "ETI",
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  BF = 1,
-  ...
-)
-
 \method{ci}{brmsfit}(
   x,
   ci = 0.95,
   method = "ETI",
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   BF = 1,
   ...
 )
-
-\method{ci}{BFBayesFactor}(x, ci = 0.95, method = "ETI", verbose = TRUE, BF = 1, ...)
-
-\method{ci}{MCMCglmm}(x, ci = 0.95, method = "ETI", verbose = TRUE, ...)
 }
 \arguments{
 \item{x}{A \code{stanreg} or \code{brmsfit} model, or a vector representing a posterior
@@ -82,12 +48,6 @@ frame to be processed. See example in \code{\link[=p_direction]{p_direction()}}.
 random effects (\code{"random"}) or both ("\verb{all"}) be returned? Only applies to
 mixed models. May be abbreviated.}
 
-\item{parameters}{Regular expression pattern that describes the parameters
-that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
-filtered by default, so only parameters that typically appear in the
-\code{summary()} are returned. Use \code{parameters} to select specific parameters
-for the output.}
-
 \item{component}{Which type of parameters to return, such as parameters for
 the conditional model, the zero-inflated part of the model, the dispersion
 term, etc. See details in section \emph{Model Components}. May be abbreviated.
@@ -104,6 +64,12 @@ but no auxiliary parameters).
 \code{sigma}, \code{dispersion}, \code{beta} or \code{precision} (and other auxiliary
 parameters) are returned.
 }}
+
+\item{parameters}{Regular expression pattern that describes the parameters
+that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
+filtered by default, so only parameters that typically appear in the
+\code{summary()} are returned. Use \code{parameters} to select specific parameters
+for the output.}
 }
 \value{
 A data frame with following columns:

--- a/man/describe_posterior.Rd
+++ b/man/describe_posterior.Rd
@@ -234,11 +234,11 @@ describe_posterior(model, rope_range = list(c(-10, 5), c(-0.2, 0.2), "default"))
 
 # emmeans estimates
 # -----------------------------------------------
-describe_posterior(emtrends(model, ~1, "wt"))
+describe_posterior(emmeans::emtrends(model, ~1, "wt"))
 
 # BayesFactor objects
 # -----------------------------------------------
-bf <- ttestBF(x = rnorm(100, 1, 1))
+bf <- BayesFactor::ttestBF(x = rnorm(100, 1, 1))
 describe_posterior(bf)
 describe_posterior(bf, centrality = "all", dispersion = TRUE, test = "all")
 describe_posterior(bf, ci = c(0.80, 0.90))

--- a/man/describe_posterior.Rd
+++ b/man/describe_posterior.Rd
@@ -5,7 +5,6 @@
 \alias{describe_posterior.numeric}
 \alias{describe_posterior.data.frame}
 \alias{describe_posterior.stanreg}
-\alias{describe_posterior.brmsfit}
 \title{Describe Posterior Distributions}
 \usage{
 describe_posterior(posterior, ...)
@@ -60,27 +59,6 @@ describe_posterior(posterior, ...)
   component = "location",
   parameters = NULL,
   BF = 1,
-  verbose = TRUE,
-  ...
-)
-
-\method{describe_posterior}{brmsfit}(
-  posterior,
-  centrality = "median",
-  dispersion = FALSE,
-  ci = 0.95,
-  ci_method = "eti",
-  test = c("p_direction", "rope"),
-  rope_range = "default",
-  rope_ci = 0.95,
-  keep_iterations = FALSE,
-  bf_prior = NULL,
-  diagnostic = c("ESS", "Rhat"),
-  effects = "fixed",
-  component = "conditional",
-  parameters = NULL,
-  BF = 1,
-  priors = FALSE,
   verbose = TRUE,
   ...
 )

--- a/man/describe_posterior.Rd
+++ b/man/describe_posterior.Rd
@@ -56,9 +56,8 @@ describe_posterior(posterior, ...)
   bf_prior = NULL,
   diagnostic = c("ESS", "Rhat"),
   priors = FALSE,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
+  effects = "fixed",
+  component = "location",
   parameters = NULL,
   BF = 1,
   verbose = TRUE,
@@ -77,9 +76,8 @@ describe_posterior(posterior, ...)
   keep_iterations = FALSE,
   bf_prior = NULL,
   diagnostic = c("ESS", "Rhat"),
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all", "location",
-    "distributional", "auxiliary"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   BF = 1,
   priors = FALSE,
@@ -183,6 +181,35 @@ One or more components of point estimates (like posterior mean or median),
 intervals and tests can be omitted from the summary output by setting the
 related argument to \code{NULL}. For example, \code{test = NULL} and \code{centrality = NULL} would only return the HDI (or CI).
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (all(insight::check_if_installed(c("logspline", "rstanarm", "emmeans", "BayesFactor"), quietly = TRUE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)
@@ -217,7 +244,10 @@ head(reshape_iterations(
 # rstanarm models
 # -----------------------------------------------
 model <- suppressWarnings(
-  rstanarm::stan_glm(mpg ~ wt + gear, data = mtcars, chains = 2, iter = 200, refresh = 0)
+  rstanarm::stan_glm(
+    mpg ~ wt + gear, data = mtcars, chains = 2, iter = 200,
+    refresh = 0
+  )
 )
 describe_posterior(model)
 describe_posterior(model, centrality = "all", dispersion = TRUE, test = "all")

--- a/man/describe_prior.Rd
+++ b/man/describe_prior.Rd
@@ -7,40 +7,12 @@
 \usage{
 describe_prior(model, ...)
 
-\method{describe_prior}{brmsfit}(
-  model,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all", "location",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  ...
-)
+\method{describe_prior}{brmsfit}(model, parameters = NULL, ...)
 }
 \arguments{
 \item{model}{A Bayesian model.}
 
 \item{...}{Currently not used.}
-
-\item{effects}{Should results for fixed effects (\code{"fixed"}, the default),
-random effects (\code{"random"}) or both ("\verb{all"}) be returned? Only applies to
-mixed models. May be abbreviated.}
-
-\item{component}{Which type of parameters to return, such as parameters for
-the conditional model, the zero-inflated part of the model, the dispersion
-term, etc. See details in section \emph{Model Components}. May be abbreviated.
-Note that the \emph{conditional} component also refers to the \emph{count} or \emph{mean}
-component - names may differ, depending on the modeling package. There are
-three convenient shortcuts (not applicable to \emph{all} model classes):
-\itemize{
-\item \code{component = "all"} returns all possible parameters.
-\item If \code{component = "location"}, location parameters such as \code{conditional},
-\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned (everything
-that are fixed or random effects - depending on the \code{effects} argument -
-but no auxiliary parameters).
-\item For \code{component = "distributional"} (or \code{"auxiliary"}), components like
-\code{sigma}, \code{dispersion}, \code{beta} or \code{precision} (and other auxiliary
-parameters) are returned.
-}}
 
 \item{parameters}{Regular expression pattern that describes the parameters
 that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are

--- a/man/diagnostic_posterior.Rd
+++ b/man/diagnostic_posterior.Rd
@@ -14,9 +14,8 @@ diagnostic_posterior(posterior, ...)
 \method{diagnostic_posterior}{stanreg}(
   posterior,
   diagnostic = "all",
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
+  effects = "fixed",
+  component = "location",
   parameters = NULL,
   ...
 )
@@ -24,8 +23,8 @@ diagnostic_posterior(posterior, ...)
 \method{diagnostic_posterior}{brmsfit}(
   posterior,
   diagnostic = "all",
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   ...
 )

--- a/man/diagnostic_posterior.Rd
+++ b/man/diagnostic_posterior.Rd
@@ -87,6 +87,35 @@ effective sample size (the formula for \code{mcse()} is from Kruschke 2015, p.
 187). The MCSE "provides a quantitative suggestion of how big the estimation
 noise is".
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm") && require("brms")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 \donttest{

--- a/man/diagnostic_posterior.Rd
+++ b/man/diagnostic_posterior.Rd
@@ -4,7 +4,6 @@
 \alias{diagnostic_posterior}
 \alias{diagnostic_posterior.default}
 \alias{diagnostic_posterior.stanreg}
-\alias{diagnostic_posterior.brmsfit}
 \title{Posteriors Sampling Diagnostic}
 \usage{
 diagnostic_posterior(posterior, ...)
@@ -16,15 +15,6 @@ diagnostic_posterior(posterior, ...)
   diagnostic = "all",
   effects = "fixed",
   component = "location",
-  parameters = NULL,
-  ...
-)
-
-\method{diagnostic_posterior}{brmsfit}(
-  posterior,
-  diagnostic = "all",
-  effects = "fixed",
-  component = "conditional",
   parameters = NULL,
   ...
 )

--- a/man/effective_sample.Rd
+++ b/man/effective_sample.Rd
@@ -3,7 +3,6 @@
 \name{effective_sample}
 \alias{effective_sample}
 \alias{effective_sample.brmsfit}
-\alias{effective_sample.stanreg}
 \title{Effective Sample Size (ESS)}
 \usage{
 effective_sample(model, ...)
@@ -12,14 +11,6 @@ effective_sample(model, ...)
   model,
   effects = "fixed",
   component = "conditional",
-  parameters = NULL,
-  ...
-)
-
-\method{effective_sample}{stanreg}(
-  model,
-  effects = "fixed",
-  component = "location",
   parameters = NULL,
   ...
 )

--- a/man/equivalence_test.Rd
+++ b/man/equivalence_test.Rd
@@ -189,7 +189,7 @@ here. See also \href{https://easystats.github.io/insight/reference/find_paramete
 }
 
 \examples{
-\dontshow{if (all(insight::check_if_installed(c("rstanarm", "brms", "emmeans", "BayesFactor"), quietly = TRUE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (all(insight::check_if_installed(c("rstanarm", "brms", "emmeans", "BayesFactor", "see"), quietly = TRUE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)
 
 equivalence_test(x = rnorm(1000, 0, 0.01), range = c(-0.1, 0.1))

--- a/man/equivalence_test.Rd
+++ b/man/equivalence_test.Rd
@@ -4,7 +4,6 @@
 \alias{equivalence_test}
 \alias{equivalence_test.default}
 \alias{equivalence_test.data.frame}
-\alias{equivalence_test.stanreg}
 \alias{equivalence_test.brmsfit}
 \title{Test for Practical Equivalence}
 \usage{
@@ -21,24 +20,12 @@ equivalence_test(x, ...)
   ...
 )
 
-\method{equivalence_test}{stanreg}(
-  x,
-  range = "default",
-  ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{equivalence_test}{brmsfit}(
   x,
   range = "default",
   ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...
@@ -172,6 +159,35 @@ the amount of digits in the output, and there is a
 \href{https://easystats.github.io/see/articles/bayestestR.html}{\code{plot()}-method}
 to visualize the results from the equivalence-test (for models only).
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (all(insight::check_if_installed(c("rstanarm", "brms", "emmeans", "BayesFactor"), quietly = TRUE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)

--- a/man/estimate_density.Rd
+++ b/man/estimate_density.Rd
@@ -3,6 +3,7 @@
 \name{estimate_density}
 \alias{estimate_density}
 \alias{estimate_density.data.frame}
+\alias{estimate_density.brmsfit}
 \title{Density Estimation}
 \usage{
 estimate_density(x, ...)
@@ -17,8 +18,20 @@ estimate_density(x, ...)
   ci = NULL,
   select = NULL,
   by = NULL,
-  at = NULL,
   rvar_col = NULL,
+  ...
+)
+
+\method{estimate_density}{brmsfit}(
+  x,
+  method = "kernel",
+  precision = 2^10,
+  extend = FALSE,
+  extend_scale = 0.1,
+  bw = "SJ",
+  effects = "fixed",
+  component = "conditional",
+  parameters = NULL,
   ...
 )
 }
@@ -55,10 +68,35 @@ numeric variables will be selected. Other arguments from
 density estimation is performed for each group (subsets) indicated by \code{by}.
 See examples.}
 
-\item{at}{Deprecated in favour of \code{by}.}
-
 \item{rvar_col}{A single character - the name of an \code{rvar} column in the data
 frame to be processed. See example in \code{\link[=p_direction]{p_direction()}}.}
+
+\item{effects}{Should results for fixed effects (\code{"fixed"}, the default),
+random effects (\code{"random"}) or both ("\verb{all"}) be returned? Only applies to
+mixed models. May be abbreviated.}
+
+\item{component}{Which type of parameters to return, such as parameters for
+the conditional model, the zero-inflated part of the model, the dispersion
+term, etc. See details in section \emph{Model Components}. May be abbreviated.
+Note that the \emph{conditional} component also refers to the \emph{count} or \emph{mean}
+component - names may differ, depending on the modeling package. There are
+three convenient shortcuts (not applicable to \emph{all} model classes):
+\itemize{
+\item \code{component = "all"} returns all possible parameters.
+\item If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned (everything
+that are fixed or random effects - depending on the \code{effects} argument -
+but no auxiliary parameters).
+\item For \code{component = "distributional"} (or \code{"auxiliary"}), components like
+\code{sigma}, \code{dispersion}, \code{beta} or \code{precision} (and other auxiliary
+parameters) are returned.
+}}
+
+\item{parameters}{Regular expression pattern that describes the parameters
+that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
+filtered by default, so only parameters that typically appear in the
+\code{summary()} are returned. Use \code{parameters} to select specific parameters
+for the output.}
 }
 \description{
 This function is a wrapper over different methods of density estimation. By
@@ -70,6 +108,35 @@ is the fastest and the most accurate.
 \note{
 There is also a \href{https://easystats.github.io/see/articles/bayestestR.html}{\code{plot()}-method} implemented in the \href{https://easystats.github.io/see/}{\pkg{see}-package}.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("logspline") && require("KernSmooth") && require("mclust") && require("emmeans") && require("rstanarm") && require("brms")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)

--- a/man/eti.Rd
+++ b/man/eti.Rd
@@ -4,7 +4,6 @@
 \alias{eti}
 \alias{eti.numeric}
 \alias{eti.data.frame}
-\alias{eti.stanreg}
 \alias{eti.brmsfit}
 \alias{eti.get_predicted}
 \title{Equal-Tailed Interval (ETI)}
@@ -15,22 +14,11 @@ eti(x, ...)
 
 \method{eti}{data.frame}(x, ci = 0.95, rvar_col = NULL, verbose = TRUE, ...)
 
-\method{eti}{stanreg}(
-  x,
-  ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{eti}{brmsfit}(
   x,
   ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...
@@ -151,6 +139,35 @@ to the transformed lower and higher bounds of the original distribution.
 On the contrary, applying transformations to the distribution will change
 the resulting HDI.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm") && require("emmeans") && require("brms") && require("BayesFactor")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)

--- a/man/hdi.Rd
+++ b/man/hdi.Rd
@@ -4,7 +4,6 @@
 \alias{hdi}
 \alias{hdi.numeric}
 \alias{hdi.data.frame}
-\alias{hdi.stanreg}
 \alias{hdi.brmsfit}
 \alias{hdi.get_predicted}
 \title{Highest Density Interval (HDI)}
@@ -15,22 +14,11 @@ hdi(x, ...)
 
 \method{hdi}{data.frame}(x, ci = 0.95, rvar_col = NULL, verbose = TRUE, ...)
 
-\method{hdi}{stanreg}(
-  x,
-  ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{hdi}{brmsfit}(
   x,
   ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...

--- a/man/map_estimate.Rd
+++ b/man/map_estimate.Rd
@@ -3,7 +3,6 @@
 \name{map_estimate}
 \alias{map_estimate}
 \alias{map_estimate.numeric}
-\alias{map_estimate.stanreg}
 \alias{map_estimate.brmsfit}
 \alias{map_estimate.data.frame}
 \alias{map_estimate.get_predicted}
@@ -13,23 +12,12 @@ map_estimate(x, ...)
 
 \method{map_estimate}{numeric}(x, precision = 2^10, method = "kernel", ...)
 
-\method{map_estimate}{stanreg}(
-  x,
-  precision = 2^10,
-  method = "kernel",
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  ...
-)
-
 \method{map_estimate}{brmsfit}(
   x,
   precision = 2^10,
   method = "kernel",
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   ...
 )
@@ -114,6 +102,35 @@ of the \emph{mode} for continuous parameters. Note that this function relies on
 (\code{"SJ"}) compared to the legacy default implemented the base R \code{\link[=density]{density()}}
 function (\code{"nrd0"}).
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm") && require("brms")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 \donttest{

--- a/man/mcse.Rd
+++ b/man/mcse.Rd
@@ -7,14 +7,7 @@
 \usage{
 mcse(model, ...)
 
-\method{mcse}{stanreg}(
-  model,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  ...
-)
+\method{mcse}{stanreg}(model, effects = "fixed", component = "location", parameters = NULL, ...)
 }
 \arguments{
 \item{model}{A \code{stanreg}, \code{stanfit}, \code{brmsfit}, \code{blavaan}, or \code{MCMCglmm} object.}
@@ -58,6 +51,35 @@ divided by their effective sample size (the formula for \code{mcse()} is
 from Kruschke 2015, p. 187). The MCSE \dQuote{provides a quantitative
 suggestion of how big the estimation noise is}.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 \donttest{

--- a/man/mediation.Rd
+++ b/man/mediation.Rd
@@ -3,23 +3,11 @@
 \name{mediation}
 \alias{mediation}
 \alias{mediation.brmsfit}
-\alias{mediation.stanmvreg}
 \title{Summary of Bayesian multivariate-response mediation-models}
 \usage{
 mediation(model, ...)
 
 \method{mediation}{brmsfit}(
-  model,
-  treatment,
-  mediator,
-  response = NULL,
-  centrality = "median",
-  ci = 0.95,
-  method = "ETI",
-  ...
-)
-
-\method{mediation}{stanmvreg}(
   model,
   treatment,
   mediator,

--- a/man/p_direction.Rd
+++ b/man/p_direction.Rd
@@ -5,12 +5,7 @@
 \alias{pd}
 \alias{p_direction.numeric}
 \alias{p_direction.data.frame}
-\alias{p_direction.MCMCglmm}
-\alias{p_direction.emmGrid}
-\alias{p_direction.slopes}
-\alias{p_direction.stanreg}
 \alias{p_direction.brmsfit}
-\alias{p_direction.BFBayesFactor}
 \alias{p_direction.get_predicted}
 \title{Probability of Direction (pd)}
 \usage{
@@ -37,60 +32,11 @@ pd(x, ...)
   ...
 )
 
-\method{p_direction}{MCMCglmm}(
-  x,
-  method = "direct",
-  null = 0,
-  as_p = FALSE,
-  remove_na = TRUE,
-  ...
-)
-
-\method{p_direction}{emmGrid}(
-  x,
-  method = "direct",
-  null = 0,
-  as_p = FALSE,
-  remove_na = TRUE,
-  ...
-)
-
-\method{p_direction}{slopes}(
-  x,
-  method = "direct",
-  null = 0,
-  as_p = FALSE,
-  remove_na = TRUE,
-  ...
-)
-
-\method{p_direction}{stanreg}(
-  x,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  method = "direct",
-  null = 0,
-  as_p = FALSE,
-  remove_na = TRUE,
-  ...
-)
-
 \method{p_direction}{brmsfit}(
   x,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
-  method = "direct",
-  null = 0,
-  as_p = FALSE,
-  remove_na = TRUE,
-  ...
-)
-
-\method{p_direction}{BFBayesFactor}(
-  x,
   method = "direct",
   null = 0,
   as_p = FALSE,
@@ -260,6 +206,35 @@ available), and then computing the \link[=area_under_curve]{area under the curve
 between them. Note the this approach assumes a continuous density function,
 and so \strong{when the posterior represents a (partially) discrete parameter
 space, only the direct method \emph{must} be used} (see above).
+}
+
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
 }
 
 \examples{

--- a/man/p_map.Rd
+++ b/man/p_map.Rd
@@ -6,7 +6,6 @@
 \alias{p_map.numeric}
 \alias{p_map.get_predicted}
 \alias{p_map.data.frame}
-\alias{p_map.stanreg}
 \alias{p_map.brmsfit}
 \title{Bayesian p-value based on the density at the Maximum A Posteriori (MAP)}
 \usage{
@@ -28,25 +27,13 @@ p_pointnull(x, ...)
 
 \method{p_map}{data.frame}(x, null = 0, precision = 2^10, method = "kernel", rvar_col = NULL, ...)
 
-\method{p_map}{stanreg}(
-  x,
-  null = 0,
-  precision = 2^10,
-  method = "kernel",
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  ...
-)
-
 \method{p_map}{brmsfit}(
   x,
   null = 0,
   precision = 2^10,
   method = "kernel",
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   ...
 )
@@ -125,6 +112,35 @@ on density approximation. Indirect relationship between mathematical
 definition and interpretation. Only suitable for weak / very diffused priors.
 }
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm") && require("emmeans") && require("brms") && require("BayesFactor")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)

--- a/man/p_rope.Rd
+++ b/man/p_rope.Rd
@@ -4,7 +4,6 @@
 \alias{p_rope}
 \alias{p_rope.numeric}
 \alias{p_rope.data.frame}
-\alias{p_rope.stanreg}
 \alias{p_rope.brmsfit}
 \title{Probability of being in the ROPE}
 \usage{
@@ -14,22 +13,11 @@ p_rope(x, ...)
 
 \method{p_rope}{data.frame}(x, range = "default", rvar_col = NULL, verbose = TRUE, ...)
 
-\method{p_rope}{stanreg}(
-  x,
-  range = "default",
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{p_rope}{brmsfit}(
   x,
   range = "default",
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...
@@ -94,6 +82,35 @@ for the output.}
 \description{
 Compute the proportion of the whole posterior distribution that doesn't lie within a region of practical equivalence (ROPE). It is equivalent to running \code{rope(..., ci = 1)}.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 library(bayestestR)
 

--- a/man/p_significance.Rd
+++ b/man/p_significance.Rd
@@ -5,7 +5,6 @@
 \alias{p_significance.numeric}
 \alias{p_significance.get_predicted}
 \alias{p_significance.data.frame}
-\alias{p_significance.stanreg}
 \alias{p_significance.brmsfit}
 \title{Practical Significance (ps)}
 \usage{
@@ -23,22 +22,11 @@ p_significance(x, ...)
 
 \method{p_significance}{data.frame}(x, threshold = "default", rvar_col = NULL, ...)
 
-\method{p_significance}{stanreg}(
-  x,
-  threshold = "default",
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{p_significance}{brmsfit}(
   x,
   threshold = "default",
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...
@@ -128,6 +116,35 @@ will be less than 0.5, which indicates no clear practical significance.
 \note{
 There is also a \href{https://easystats.github.io/see/articles/bayestestR.html}{\code{plot()}-method} implemented in the \href{https://easystats.github.io/see/}{\pkg{see}-package}.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)

--- a/man/point_estimate.Rd
+++ b/man/point_estimate.Rd
@@ -4,9 +4,7 @@
 \alias{point_estimate}
 \alias{point_estimate.numeric}
 \alias{point_estimate.data.frame}
-\alias{point_estimate.stanreg}
 \alias{point_estimate.brmsfit}
-\alias{point_estimate.BFBayesFactor}
 \alias{point_estimate.get_predicted}
 \title{Point-estimates of posterior distributions}
 \usage{
@@ -23,28 +21,15 @@ point_estimate(x, ...)
   ...
 )
 
-\method{point_estimate}{stanreg}(
-  x,
-  centrality = "all",
-  dispersion = FALSE,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  ...
-)
-
 \method{point_estimate}{brmsfit}(
   x,
   centrality = "all",
   dispersion = FALSE,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   ...
 )
-
-\method{point_estimate}{BFBayesFactor}(x, centrality = "all", dispersion = FALSE, ...)
 
 \method{point_estimate}{get_predicted}(
   x,
@@ -120,6 +105,35 @@ Compute various point-estimates, such as the mean, the median or the MAP, to des
 \note{
 There is also a \href{https://easystats.github.io/see/articles/bayestestR.html}{\code{plot()}-method} implemented in the \href{https://easystats.github.io/see/}{\pkg{see}-package}.
 }
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
+}
+
 \examples{
 \dontshow{if (require("rstanarm") && require("emmeans") && require("brms") && require("BayesFactor")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(bayestestR)

--- a/man/rope.Rd
+++ b/man/rope.Rd
@@ -221,7 +221,7 @@ rope(model)
 rope(model, ci = c(0.90, 0.95))
 
 model <- brms::brm(
-  brmsbrms::bf(brms::mvbind(mpg, disp) ~ wt + cyl) + brms::set_rescor(rescor = TRUE),
+  brms::bf(brms::mvbind(mpg, disp) ~ wt + cyl) + brms::set_rescor(rescor = TRUE),
   data = mtcars,
   refresh = 0
 )

--- a/man/rope.Rd
+++ b/man/rope.Rd
@@ -4,7 +4,6 @@
 \alias{rope}
 \alias{rope.numeric}
 \alias{rope.data.frame}
-\alias{rope.stanreg}
 \alias{rope.brmsfit}
 \title{Region of Practical Equivalence (ROPE)}
 \usage{
@@ -22,26 +21,13 @@ rope(x, ...)
   ...
 )
 
-\method{rope}{stanreg}(
-  x,
-  range = "default",
-  ci = 0.95,
-  ci_method = "ETI",
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{rope}{brmsfit}(
   x,
   range = "default",
   ci = 0.95,
   ci_method = "ETI",
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...
@@ -176,6 +162,35 @@ the effects.
 \strong{Limitations:} A ROPE range needs to be arbitrarily defined. Sensitive to
 the scale (the unit) of the predictors. Not sensitive to highly significant
 effects.
+}
+
+\section{Model components}{
+
+
+Possible values for the \code{component} argument depend on the model class.
+Following are valid options:
+\itemize{
+\item \code{"all"}: returns all model components, applies to all models, but will only
+have an effect for models with more than just the conditional model
+component.
+\item \code{"conditional"}: only returns the conditional component, i.e. "fixed
+effects" terms from the model. Will only have an effect for models with
+more than just the conditional model component.
+\item \code{"smooth_terms"}: returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms).
+\item \code{"zero_inflated"} (or \code{"zi"}): returns the zero-inflation component.
+\item \code{"location"}: returns location parameters such as \code{conditional},
+\code{zero_inflated}, or \code{smooth_terms} (everything that are fixed or random
+effects - depending on the \code{effects} argument - but no auxiliary
+parameters).
+\item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma},
+\code{dispersion}, \code{beta} or \code{precision} (and other auxiliary parameters) are
+returned.
+}
+
+For models of class \code{brmsfit} (package \strong{brms}), even more options are
+possible for the \code{component} argument, which are not all documented in detail
+here. See also \href{https://easystats.github.io/insight/reference/find_parameters.BGGM.html}{\code{?insight::find_parameters}}.
 }
 
 \examples{

--- a/man/si.Rd
+++ b/man/si.Rd
@@ -4,9 +4,6 @@
 \alias{si}
 \alias{si.numeric}
 \alias{si.stanreg}
-\alias{si.brmsfit}
-\alias{si.blavaan}
-\alias{si.emmGrid}
 \alias{si.get_predicted}
 \alias{si.data.frame}
 \title{Compute Support Intervals}
@@ -20,38 +17,11 @@ si(posterior, ...)
   prior = NULL,
   BF = 1,
   verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "conditional", "all", "smooth_terms", "sigma", "auxiliary",
-    "distributional"),
+  effects = "fixed",
+  component = "location",
   parameters = NULL,
   ...
 )
-
-\method{si}{brmsfit}(
-  posterior,
-  prior = NULL,
-  BF = 1,
-  verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "conditional", "all", "smooth_terms", "sigma", "auxiliary",
-    "distributional"),
-  parameters = NULL,
-  ...
-)
-
-\method{si}{blavaan}(
-  posterior,
-  prior = NULL,
-  BF = 1,
-  verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "conditional", "all", "smooth_terms", "sigma", "auxiliary",
-    "distributional"),
-  parameters = NULL,
-  ...
-)
-
-\method{si}{emmGrid}(posterior, prior = NULL, BF = 1, verbose = TRUE, ...)
 
 \method{si}{get_predicted}(
   posterior,

--- a/man/simulate_prior.Rd
+++ b/man/simulate_prior.Rd
@@ -50,6 +50,8 @@ that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
 filtered by default, so only parameters that typically appear in the
 \code{summary()} are returned. Use \code{parameters} to select specific parameters
 for the output.}
+
+\item{verbose}{Toggle off warnings.}
 }
 \description{
 Transforms priors information to actual distributions.

--- a/man/simulate_prior.Rd
+++ b/man/simulate_prior.Rd
@@ -2,9 +2,20 @@
 % Please edit documentation in R/simulate_priors.R
 \name{simulate_prior}
 \alias{simulate_prior}
+\alias{simulate_prior.brmsfit}
 \title{Returns Priors of a Model as Empirical Distributions}
 \usage{
 simulate_prior(model, n = 1000, ...)
+
+\method{simulate_prior}{brmsfit}(
+  model,
+  n = 1000,
+  effects = "fixed",
+  component = "conditional",
+  parameters = NULL,
+  verbose = TRUE,
+  ...
+)
 }
 \arguments{
 \item{model}{A \code{stanreg}, \code{stanfit}, \code{brmsfit}, \code{blavaan}, or \code{MCMCglmm} object.}
@@ -12,6 +23,33 @@ simulate_prior(model, n = 1000, ...)
 \item{n}{Size of the simulated prior distributions.}
 
 \item{...}{Currently not used.}
+
+\item{effects}{Should results for fixed effects (\code{"fixed"}, the default),
+random effects (\code{"random"}) or both ("\verb{all"}) be returned? Only applies to
+mixed models. May be abbreviated.}
+
+\item{component}{Which type of parameters to return, such as parameters for
+the conditional model, the zero-inflated part of the model, the dispersion
+term, etc. See details in section \emph{Model Components}. May be abbreviated.
+Note that the \emph{conditional} component also refers to the \emph{count} or \emph{mean}
+component - names may differ, depending on the modeling package. There are
+three convenient shortcuts (not applicable to \emph{all} model classes):
+\itemize{
+\item \code{component = "all"} returns all possible parameters.
+\item If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned (everything
+that are fixed or random effects - depending on the \code{effects} argument -
+but no auxiliary parameters).
+\item For \code{component = "distributional"} (or \code{"auxiliary"}), components like
+\code{sigma}, \code{dispersion}, \code{beta} or \code{precision} (and other auxiliary
+parameters) are returned.
+}}
+
+\item{parameters}{Regular expression pattern that describes the parameters
+that should be returned. Meta-parameters (like \code{lp__} or \code{prior_}) are
+filtered by default, so only parameters that typically appear in the
+\code{summary()} are returned. Use \code{parameters} to select specific parameters
+for the output.}
 }
 \description{
 Transforms priors information to actual distributions.

--- a/man/spi.Rd
+++ b/man/spi.Rd
@@ -4,7 +4,6 @@
 \alias{spi}
 \alias{spi.numeric}
 \alias{spi.data.frame}
-\alias{spi.stanreg}
 \alias{spi.brmsfit}
 \alias{spi.get_predicted}
 \title{Shortest Probability Interval (SPI)}
@@ -15,22 +14,11 @@ spi(x, ...)
 
 \method{spi}{data.frame}(x, ci = 0.95, rvar_col = NULL, verbose = TRUE, ...)
 
-\method{spi}{stanreg}(
-  x,
-  ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("location", "all", "conditional", "smooth_terms", "sigma",
-    "distributional", "auxiliary"),
-  parameters = NULL,
-  verbose = TRUE,
-  ...
-)
-
 \method{spi}{brmsfit}(
   x,
   ci = 0.95,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL,
   verbose = TRUE,
   ...

--- a/man/unupdate.Rd
+++ b/man/unupdate.Rd
@@ -3,11 +3,14 @@
 \name{unupdate}
 \alias{unupdate}
 \alias{unupdate.brmsfit}
+\alias{unupdate.brmsfit_multiple}
 \title{Un-update Bayesian models to their prior-to-data state}
 \usage{
 unupdate(model, verbose = TRUE, ...)
 
 \method{unupdate}{brmsfit}(model, verbose = TRUE, ...)
+
+\method{unupdate}{brmsfit_multiple}(model, verbose = TRUE, newdata = NULL, ...)
 }
 \arguments{
 \item{model}{A fitted Bayesian model.}

--- a/man/unupdate.Rd
+++ b/man/unupdate.Rd
@@ -2,21 +2,12 @@
 % Please edit documentation in R/unupdate.R
 \name{unupdate}
 \alias{unupdate}
-\alias{unupdate.stanreg}
 \alias{unupdate.brmsfit}
-\alias{unupdate.brmsfit_multiple}
-\alias{unupdate.blavaan}
 \title{Un-update Bayesian models to their prior-to-data state}
 \usage{
 unupdate(model, verbose = TRUE, ...)
 
-\method{unupdate}{stanreg}(model, verbose = TRUE, ...)
-
 \method{unupdate}{brmsfit}(model, verbose = TRUE, ...)
-
-\method{unupdate}{brmsfit_multiple}(model, verbose = TRUE, newdata = NULL, ...)
-
-\method{unupdate}{blavaan}(model, verbose = TRUE, ...)
 }
 \arguments{
 \item{model}{A fitted Bayesian model.}

--- a/man/weighted_posteriors.Rd
+++ b/man/weighted_posteriors.Rd
@@ -4,6 +4,7 @@
 \alias{weighted_posteriors}
 \alias{weighted_posteriors.data.frame}
 \alias{weighted_posteriors.stanreg}
+\alias{weighted_posteriors.BFBayesFactor}
 \title{Generate posterior distributions weighted across models}
 \usage{
 weighted_posteriors(..., prior_odds = NULL, missing = 0, verbose = TRUE)
@@ -18,6 +19,14 @@ weighted_posteriors(..., prior_odds = NULL, missing = 0, verbose = TRUE)
   effects = "fixed",
   component = "conditional",
   parameters = NULL
+)
+
+\method{weighted_posteriors}{BFBayesFactor}(
+  ...,
+  prior_odds = NULL,
+  missing = 0,
+  verbose = TRUE,
+  iterations = 4000
 )
 }
 \arguments{

--- a/man/weighted_posteriors.Rd
+++ b/man/weighted_posteriors.Rd
@@ -4,9 +4,6 @@
 \alias{weighted_posteriors}
 \alias{weighted_posteriors.data.frame}
 \alias{weighted_posteriors.stanreg}
-\alias{weighted_posteriors.brmsfit}
-\alias{weighted_posteriors.blavaan}
-\alias{weighted_posteriors.BFBayesFactor}
 \title{Generate posterior distributions weighted across models}
 \usage{
 weighted_posteriors(..., prior_odds = NULL, missing = 0, verbose = TRUE)
@@ -18,37 +15,9 @@ weighted_posteriors(..., prior_odds = NULL, missing = 0, verbose = TRUE)
   prior_odds = NULL,
   missing = 0,
   verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
+  effects = "fixed",
+  component = "conditional",
   parameters = NULL
-)
-
-\method{weighted_posteriors}{brmsfit}(
-  ...,
-  prior_odds = NULL,
-  missing = 0,
-  verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
-  parameters = NULL
-)
-
-\method{weighted_posteriors}{blavaan}(
-  ...,
-  prior_odds = NULL,
-  missing = 0,
-  verbose = TRUE,
-  effects = c("fixed", "random", "all"),
-  component = c("conditional", "zi", "zero_inflated", "all"),
-  parameters = NULL
-)
-
-\method{weighted_posteriors}{BFBayesFactor}(
-  ...,
-  prior_odds = NULL,
-  missing = 0,
-  verbose = TRUE,
-  iterations = 4000
 )
 }
 \arguments{


### PR DESCRIPTION
This PR removes multiple options for the  `effects` and `component` arguments, leaving only the main option, to make docs clearer.

Furthermore, options are now better documented, and checks are now done in *insight*.