### PR TITLE
Improved efficiency for `describe_posterior()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bayestestR
 Title: Understand and Describe Bayesian Models and Posterior Distributions
-Version: 0.16.0
+Version: 0.16.0.1
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# bayestestR (devel)
+
+## Changes
+
+* Improved efficiency for `describe_posterior()`.
+
 # bayestestR 0.16.0
 
 ## Changes

--- a/R/bayesfactor_parameters.R
+++ b/R/bayesfactor_parameters.R
@@ -296,7 +296,7 @@ bayesfactor_parameters.stanreg <- function(posterior,
                                            parameters = NULL,
                                            ...,
                                            verbose = TRUE) {
-  cleaned_parameters <- insight::clean_parameters(posterior)
+  cleaned_parameters <- .get_cleaned_parameters(posterior, ...)
 
   samps <- .clean_priors_and_posteriors(posterior, prior,
     effects = effects, component = component,

--- a/R/bci.R
+++ b/R/bci.R
@@ -214,7 +214,7 @@ bci.stanreg <- function(x,
       verbose = verbose,
       ...
     ),
-    insight::clean_parameters(x),
+    .get_cleaned_parameters(x, ...),
     inherits(x, "stanmvreg")
   )
 
@@ -252,7 +252,7 @@ bci.brmsfit <- function(x,
       verbose = verbose,
       ...
     ),
-    insight::clean_parameters(x)
+    .get_cleaned_parameters(x, ...)
   )
 
   class(out) <- unique(c("bayestestR_eti", "see_eti", class(out)))

--- a/R/check_prior.R
+++ b/R/check_prior.R
@@ -87,7 +87,7 @@ check_prior.brmsfit <- function(model,
 
   .check_prior(priors, posteriors, method,
     verbose = verbose,
-    cleaned_parameters = insight::clean_parameters(model)
+    cleaned_parameters = .get_cleaned_parameters(model, ...)
   )
 }
 

--- a/R/describe_posterior.R
+++ b/R/describe_posterior.R
@@ -174,7 +174,13 @@ describe_posterior.default <- function(posterior, ...) {
     estimates <- data.frame(Parameter = NA)
   } else {
     estimates <- .prepare_output(
-      point_estimate(x_df, centrality = centrality, dispersion = dispersion, ...),
+      point_estimate(
+        x_df,
+        centrality = centrality,
+        dispersion = dispersion,
+        cleaned_parameters = cleaned_parameters,
+        ...
+      ),
       cleaned_parameters,
       is_stanmvreg
     )
@@ -198,9 +204,24 @@ describe_posterior.default <- function(posterior, ...) {
     )
     # not sure why "si" requires the model object
     if (ci_method == "si") {
-      uncertainty <- ci(x, BF = BF, method = ci_method, prior = bf_prior, verbose = verbose, ...)
+      uncertainty <- ci(
+        x,
+        BF = BF,
+        method = ci_method,
+        prior = bf_prior,
+        verbose = verbose,
+        cleaned_parameters = cleaned_parameters,
+        ...
+      )
     } else {
-      uncertainty <- ci(x_df, ci = ci, method = ci_method, verbose = verbose, ...)
+      uncertainty <- ci(
+        x_df,
+        ci = ci,
+        method = ci_method,
+        verbose = verbose,
+        cleaned_parameters = cleaned_parameters,
+        ...
+      )
     }
     uncertainty <- .prepare_output(
       uncertainty,
@@ -288,7 +309,7 @@ describe_posterior.default <- function(posterior, ...) {
 
     if (any(c("p_map", "p_pointnull") %in% test)) {
       test_pmap <- .prepare_output(
-        p_map(x_df, ...),
+        p_map(x_df, cleaned_parameters = cleaned_parameters, ...),
         cleaned_parameters,
         is_stanmvreg
       )
@@ -308,7 +329,7 @@ describe_posterior.default <- function(posterior, ...) {
 
     if (any(c("pd", "p_direction", "pdir", "mpe") %in% test)) {
       test_pd <- .prepare_output(
-        p_direction(x_df, ...),
+        p_direction(x_df, cleaned_parameters = cleaned_parameters, ...),
         cleaned_parameters,
         is_stanmvreg
       )
@@ -327,7 +348,13 @@ describe_posterior.default <- function(posterior, ...) {
 
     if ("p_rope" %in% test) {
       test_prope <- .prepare_output(
-        p_rope(x_df, range = rope_range, verbose = verbose, ...),
+        p_rope(
+          x_df,
+          range = rope_range,
+          verbose = verbose,
+          cleaned_parameters = cleaned_parameters,
+          ...
+        ),
         cleaned_parameters,
         is_stanmvreg
       )
@@ -345,7 +372,12 @@ describe_posterior.default <- function(posterior, ...) {
 
     if (any(c("ps", "p_sig", "p_significance") %in% test)) {
       test_psig <- .prepare_output(
-        p_significance(x_df, threshold = rope_range, ...),
+        p_significance(
+          x_df,
+          threshold = rope_range,
+          cleaned_parameters = cleaned_parameters,
+          ...
+        ),
         cleaned_parameters,
         is_stanmvreg
       )
@@ -365,7 +397,13 @@ describe_posterior.default <- function(posterior, ...) {
 
     if ("rope" %in% test) {
       test_rope <- .prepare_output(
-        rope(x_df, range = rope_range, ci = rope_ci, ...),
+        rope(
+          x_df,
+          range = rope_range,
+          ci = rope_ci,
+          cleaned_parameters = cleaned_parameters,
+          ...
+        ),
         cleaned_parameters,
         is_stanmvreg
       )
@@ -528,6 +566,7 @@ describe_posterior.default <- function(posterior, ...) {
   }
 
   # Prepare output
+  attr(out, "cleaned_parameters") <- cleaned_parameters
   attr(out, "ci_method") <- ci_method
   out
 }
@@ -993,6 +1032,9 @@ describe_posterior.stanreg <- function(posterior,
     ...
   )
 
+  # intermediate step: save cleaned parameters
+  cp <- attributes(out)$cleaned_parameters
+
   diagnostic <- diagnostic_posterior(
     posterior,
     diagnostic,
@@ -1008,7 +1050,7 @@ describe_posterior.stanreg <- function(posterior,
     out <- .merge_and_sort(out, priors_data, by = "Parameter", all = TRUE)
   }
 
-  out <- .add_clean_parameters_attribute(out, posterior)
+  out <- .add_clean_parameters_attribute(out, posterior, cleaned_parameters = cp)
   attr(out, "ci_method") <- ci_method
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(posterior))
   class(out) <- c("describe_posterior", "see_describe_posterior", class(out))
@@ -1053,6 +1095,9 @@ describe_posterior.stanmvreg <- function(posterior,
     ...
   )
 
+  # intermediate step: save cleaned parameters
+  cp <- attributes(out)$cleaned_parameters
+
   if (is.null(out$Response)) {
     out$Response <- gsub("(b\\[)*(.*)\\|(.*)", "\\2", out$Parameter)
   }
@@ -1072,7 +1117,7 @@ describe_posterior.stanmvreg <- function(posterior,
     out <- .merge_and_sort(out, priors_data, by = c("Parameter", "Response"), all = TRUE)
   }
 
-  out <- .add_clean_parameters_attribute(out, posterior)
+  out <- .add_clean_parameters_attribute(out, posterior, cleaned_parameters = cp)
   attr(out, "ci_method") <- ci_method
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(posterior))
   class(out) <- c("describe_posterior", "see_describe_posterior", class(out))
@@ -1177,6 +1222,9 @@ describe_posterior.brmsfit <- function(posterior,
     ...
   )
 
+  # intermediate step: save cleaned parameters
+  cp <- attributes(out)$cleaned_parameters
+
   if (!is.null(diagnostic)) {
     diagnostic <- diagnostic_posterior(
       posterior,
@@ -1194,7 +1242,7 @@ describe_posterior.brmsfit <- function(posterior,
     out <- .merge_and_sort(out, priors_data, by = "Parameter", all = TRUE)
   }
 
-  out <- .add_clean_parameters_attribute(out, posterior)
+  out <- .add_clean_parameters_attribute(out, posterior, cleaned_parameters = cp)
   attr(out, "ci_method") <- ci_method
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(posterior))
   class(out) <- c("describe_posterior", "see_describe_posterior", class(out))

--- a/R/equivalence_test.R
+++ b/R/equivalence_test.R
@@ -305,7 +305,7 @@ equivalence_test.stanreg <- function(x,
 
   out <- .prepare_output(
     out,
-    insight::clean_parameters(x),
+    .get_cleaned_parameters(x, ...),
     inherits(x, "stanmvreg")
   )
 
@@ -344,7 +344,7 @@ equivalence_test.brmsfit <- function(x,
 
   out <- .prepare_output(
     out,
-    insight::clean_parameters(x),
+    .get_cleaned_parameters(x, ...),
     inherits(x, "stanmvreg")
   )
 

--- a/R/eti.R
+++ b/R/eti.R
@@ -238,7 +238,7 @@ eti.stanreg <- function(x,
       verbose = verbose,
       ...
     ),
-    insight::clean_parameters(x),
+    .get_cleaned_parameters(x, ...),
     inherits(x, "stanmvreg")
   )
 
@@ -275,7 +275,7 @@ eti.brmsfit <- function(x,
       verbose = verbose,
       ...
     ),
-    insight::clean_parameters(x)
+    .get_cleaned_parameters(x, ...)
   )
 
   class(out) <- unique(c("bayestestR_eti", "see_eti", class(out)))

--- a/R/hdi.R
+++ b/R/hdi.R
@@ -355,7 +355,7 @@ hdi.stanreg <- function(x,
                         parameters = NULL,
                         verbose = TRUE,
                         ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     hdi(
@@ -395,7 +395,7 @@ hdi.brmsfit <- function(x,
                         parameters = NULL,
                         verbose = TRUE,
                         ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     hdi(

--- a/R/map_estimate.R
+++ b/R/map_estimate.R
@@ -135,7 +135,7 @@ map_estimate.mcmc.list <- map_estimate.bayesQR
     row.names = NULL
   )
 
-  out <- .add_clean_parameters_attribute(out, x)
+  out <- .add_clean_parameters_attribute(out, x, ...)
   attr(out, "MAP_density") <- sapply(l, attr, "MAP_density")
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   attr(out, "centrality") <- "map"

--- a/R/p_direction.R
+++ b/R/p_direction.R
@@ -524,7 +524,7 @@ p_direction.stanreg <- function(x,
                                 as_p = FALSE,
                                 remove_na = TRUE,
                                 ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     p_direction(
@@ -569,7 +569,7 @@ p_direction.brmsfit <- function(x,
                                 as_p = FALSE,
                                 remove_na = TRUE,
                                 ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     p_direction(

--- a/R/p_map.R
+++ b/R/p_map.R
@@ -332,7 +332,7 @@ p_map.stanreg <- function(x,
                           component = "location",
                           parameters = NULL,
                           ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     p_map(
@@ -374,7 +374,7 @@ p_map.brmsfit <- function(x,
                           component = "conditional",
                           parameters = NULL,
                           ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     p_map(

--- a/R/p_rope.R
+++ b/R/p_rope.R
@@ -124,7 +124,7 @@ p_rope.stanreg <- function(x,
     verbose = verbose,
     ...
   ))
-  out <- .add_clean_parameters_attribute(out, x)
+  out <- .add_clean_parameters_attribute(out, x, ...)
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   out
 }
@@ -155,7 +155,7 @@ p_rope.brmsfit <- function(x,
     verbose = verbose,
     ...
   ))
-  out <- .add_clean_parameters_attribute(out, x)
+  out <- .add_clean_parameters_attribute(out, x, ...)
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   out
 }

--- a/R/p_significance.R
+++ b/R/p_significance.R
@@ -309,7 +309,7 @@ p_significance.stanreg <- function(x,
   )
   result <- p_significance(params, threshold = threshold)
 
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
   out <- .prepare_output(result, cleaned_parameters, inherits(x, "stanmvreg"))
 
   attr(out, "clean_parameters") <- cleaned_parameters
@@ -352,7 +352,7 @@ p_significance.brmsfit <- function(x,
   )
   result <- p_significance(params, threshold = threshold)
 
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
   out <- .prepare_output(result, cleaned_parameters)
 
   attr(out, "clean_parameters") <- cleaned_parameters

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -279,7 +279,7 @@ point_estimate.stanreg <- function(x,
                                    component = "location",
                                    parameters = NULL,
                                    ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     point_estimate(
@@ -321,7 +321,7 @@ point_estimate.brmsfit <- function(x,
                                    component = "conditional",
                                    parameters = NULL,
                                    ...) {
-  cleaned_parameters <- insight::clean_parameters(x)
+  cleaned_parameters <- .get_cleaned_parameters(x, ...)
 
   out <- .prepare_output(
     point_estimate(

--- a/R/rope.R
+++ b/R/rope.R
@@ -482,7 +482,11 @@ rope.stanreg <- function(x,
     ...
   )
 
-  out <- .prepare_output(rope_data, insight::clean_parameters(x), inherits(x, "stanmvreg"))
+  out <- .prepare_output(
+    rope_data,
+    .get_cleaned_parameters(x, ...),
+    inherits(x, "stanmvreg")
+  )
 
   attr(out, "HDI_area") <- attr(rope_data, "HDI_area")
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
@@ -567,7 +571,11 @@ rope.brmsfit <- function(x,
     )
     rope_data <- do.call(rbind, rope_data)
 
-    out <- .prepare_output(rope_data, insight::clean_parameters(x), is_brms_mv = TRUE)
+    out <- .prepare_output(
+      rope_data,
+      .get_cleaned_parameters(x, ...),
+      is_brms_mv = TRUE
+    )
   } else {
     rope_data <- rope(
       insight::get_parameters(x, effects = effects, component = component, parameters = parameters),
@@ -578,7 +586,7 @@ rope.brmsfit <- function(x,
       ...
     )
 
-    out <- .prepare_output(rope_data, insight::clean_parameters(x))
+    out <- .prepare_output(rope_data, .get_cleaned_parameters(x, ...))
   }
 
   attr(out, "HDI_area") <- attr(rope_data, "HDI_area")

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,17 +3,20 @@
   tryCatch(code, error = function(e) on_error)
 }
 
+
 # select rows where values in "variable" match "value"
 #' @keywords internal
 .select_rows <- function(data, variable, value) {
   data[which(data[[variable]] == value), ]
 }
 
+
 #' select numerics columns
 #' @keywords internal
 .select_nums <- function(x) {
   x[unlist(lapply(x, is.numeric))]
 }
+
 
 #' @keywords internal
 .retrieve_model <- function(x) {
@@ -38,6 +41,7 @@
   model
 }
 
+
 #' @keywords internal
 .dynGet <- function(x,
                     ifnotfound = stop(gettextf("%s not found", sQuote(x)), domain = NA, call. = FALSE),
@@ -56,6 +60,7 @@
   }
   ifnotfound
 }
+
 
 #' @keywords internal
 .get_direction <- function(direction) {
@@ -172,10 +177,12 @@
   }
 }
 
+
 #' @keywords internal
 .is_baysian_grid <- function(x) {
   UseMethod(".is_baysian_grid")
 }
+
 
 #' @keywords internal
 .is_baysian_grid.emmGrid <- function(x) {
@@ -186,25 +193,30 @@
   !(all(dim(post.beta) == 1) && is.na(post.beta))
 }
 
+
 #' @keywords internal
 .is_baysian_grid.emm_list <- .is_baysian_grid.emmGrid
+
 
 #' @keywords internal
 .is_baysian_grid.slopes <- function(x) {
   !is.null(attr(x, "posterior_draws"))
 }
 
+
 #' @keywords internal
 .is_baysian_grid.predictions <- .is_baysian_grid.slopes
+
 
 #' @keywords internal
 .is_baysian_grid.comparisons <- .is_baysian_grid.slopes
 
+
 # safe add cleaned parameter names to a model object
-.add_clean_parameters_attribute <- function(params, model) {
+.add_clean_parameters_attribute <- function(params, model, ...) {
   cp <- tryCatch(
     {
-      insight::clean_parameters(model)
+      .get_cleaned_parameters(model, ...)
     },
     error = function(e) {
       NULL
@@ -214,10 +226,12 @@
   params
 }
 
+
 #' @keywords internal
 .append_datagrid <- function(results, object, long = FALSE) {
   UseMethod(".append_datagrid", object = object)
 }
+
 
 #' @keywords internal
 .append_datagrid.emmGrid <- function(results, object, long = FALSE) {
@@ -303,6 +317,7 @@
   insight::check_if_installed("marginaleffects", minimum_version = "0.24.0")
   data.frame(marginaleffects::get_draws(object, shape = "DxP"))
 }
+
 
 #' @keywords internal
 .possibly_extract_rvar_col <- function(df, rvar_col) {

--- a/R/utils_clean_stan_parameters.R
+++ b/R/utils_clean_stan_parameters.R
@@ -21,3 +21,13 @@
   # tmp$Parameter <- gsub("r_(.*)\\.(.*)\\.", "\\1", tmp$Parameter)
   tmp
 }
+
+
+#' @keywords internal
+.get_cleaned_parameters <- function(x, ...) {
+  dots <- list(...)
+  if ("cleaned_parameters" %in% names(dots)) {
+    return(dots$cleaned_parameters)
+  }
+  insight::clean_parameters(x)
+}


### PR DESCRIPTION
Avoid redundant multiple calls to `insight::clean_parameters()`, which can be inefficient for larger / more complex models.