### PR TITLE
Fixed .check_multicollinearity util function

### DIFF
--- a/R/utils_check_collinearity.R
+++ b/R/utils_check_collinearity.R
@@ -55,7 +55,8 @@
 
         # Filter by first threshold
         threshold <- pmin(threshold, 0.9)
-        possible_collinear <- results[results$corr > threshold & results$corr <= 0.9, ]
+        possible_collinear <- results[which(results$corr > threshold & results$corr <= 0.9), ]
+
         if (nrow(possible_collinear) > 0) {
           where <- paste0(
             "between ",
@@ -72,7 +73,7 @@
         }
 
         # Filter by second threshold
-        probable_collinear <- results[results$corr > 0.9, ]
+        probable_collinear <- results[which(results$corr > 0.9), ]
         if (nrow(probable_collinear) > 0) {
           where <- paste0(
             "between ",

--- a/R/utils_check_collinearity.R
+++ b/R/utils_check_collinearity.R
@@ -55,11 +55,11 @@
 
         # Filter by first threshold
         threshold <- pmin(threshold, 0.9)
-        results <- results[results$corr > threshold & results$corr <= 0.9, ]
-        if (nrow(results) > 0) {
+        possible_collinear <- results[results$corr > threshold & results$corr <= 0.9, ]
+        if (nrow(possible_collinear) > 0) {
           where <- paste0(
             "between ",
-            toString(paste0(results$where, " (r = ", round(results$corr, 2), ")")),
+            toString(paste0(possible_collinear$where, " (r = ", round(possible_collinear$corr, 2), ")")),
             ""
           )
           insight::format_alert(paste0(
@@ -72,11 +72,11 @@
         }
 
         # Filter by second threshold
-        results <- results[results$corr > 0.9, ]
-        if (nrow(results) > 0) {
+        probable_collinear <- results[results$corr > 0.9, ]
+        if (nrow(probable_collinear) > 0) {
           where <- paste0(
             "between ",
-            toString(paste0(results$where, " (r = ", round(results$corr, 2), ")")),
+            toString(paste0(probable_collinear$where, " (r = ", round(probable_collinear$corr, 2), ")")),
             ""
           )
           insight::format_alert(paste0(


### PR DESCRIPTION


# Description

The .check_multicollinearity function previously was setup so that it could never flag probable collinearity (>0.9), becuase the filtering by the first threshold changed the results df. 

# Proposed Changes

Changed so that either threshold can be triggered (created a different df for probable and possible collinearity)

# Notes
First PR so please let me know if I have done anything incorrectly!
