### PR TITLE
Estimate the BCa acceleration from the skewness of the draws

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,7 @@ Suggests:
     betareg,
     BH,
     blavaan,
+    boot,
     bridgesampling (>= 1.2-1),
     brms,
     collapse,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,14 @@
 
 * `p_to_bf()` documentation improvements as well as better implementation for models (and mixed models).
 
+## Bug fixes
+
+* `bci()` now estimates the acceleration parameter as one sixth of the
+  standardized third moment of the draws. The previous estimate applied the
+  jackknife influence formula to the draws themselves, which flipped the sign
+  of the acceleration and shrank it toward zero as the number of draws grew,
+  so that intervals were adjusted in the wrong direction (#572).
+
 # bayestestR 0.18.1
 
 ## Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# bayestestR 0.18.1.x
+# bayestestR (devel)
 
 ## Breaking Changes
 

--- a/R/bci.R
+++ b/R/bci.R
@@ -306,10 +306,24 @@ bci.get_predicted <- function(x, ci = 0.95, use_iterations = FALSE, verbose = TR
   z.inv <- length(x[x < mean(x, na.rm = TRUE)]) / sims
 
   z <- stats::qnorm(z.inv)
-  U <- (sims - 1) * (mean(x, na.rm = TRUE) - x)
-  top <- sum(U^3)
-  under <- 6 * (sum(U^2))^1.5
-  a <- top / under
+
+  # no draw below the mean: the draws are constant, the interval is a point
+  if (!is.finite(z)) {
+    return(data.frame(
+      CI = ci,
+      CI_low = min(x, na.rm = TRUE),
+      CI_high = max(x, na.rm = TRUE)
+    ))
+  }
+
+  # The draws estimate the distribution of the statistic directly, so the
+  # acceleration is one sixth of their standardized third moment: for a smooth
+  # statistic this converges to the jackknife estimator of DiCiccio & Efron
+  # (1996, eq. 6.6), and unlike the influence formula it does not depend on
+  # the number of draws.
+  deviation <- x - mean(x, na.rm = TRUE)
+  a <- mean(deviation^3, na.rm = TRUE) / (6 * mean(deviation^2, na.rm = TRUE)^1.5)
+  if (!is.finite(a)) a <- 0
 
   lower.inv <- stats::pnorm(z + (z + stats::qnorm(low)) / (1 - a * (z + stats::qnorm(low))))
   lower <- stats::quantile(x, lower.inv, names = FALSE, na.rm = TRUE)

--- a/R/bci.R
+++ b/R/bci.R
@@ -294,6 +294,7 @@ bci.get_predicted <- function(x, ci = 0.95, use_iterations = FALSE, verbose = TR
 
 
 .bci <- function(x, ci, verbose = TRUE) {
+  x <- x[!is.na(x)]
   check_ci <- .check_ci_argument(x, ci, verbose)
 
   if (!is.null(check_ci)) {

--- a/tests/testthat/test-bci.R
+++ b/tests/testthat/test-bci.R
@@ -44,3 +44,13 @@ test_that("bci() handles constant draws", {
   out <- bci(rep(1, 100), verbose = FALSE)
   expect_identical(c(out$CI_low, out$CI_high), c(1, 1))
 })
+
+test_that("bci() handles missing draws", {
+  x <- c(seq_len(100), NA_real_)
+  out <- bci(x)
+  expected <- bci(x[!is.na(x)])
+  expect_equal(out[c("CI", "CI_low", "CI_high")], expected[c("CI", "CI_low", "CI_high")])
+
+  out <- bci(rep(NA_real_, 100), verbose = FALSE)
+  expect_true(all(is.na(c(out$CI_low, out$CI_high))))
+})

--- a/tests/testthat/test-bci.R
+++ b/tests/testthat/test-bci.R
@@ -1,0 +1,46 @@
+test_that("bci() acceleration agrees with the jackknife estimator from boot", {
+  skip_if_not_installed("boot")
+
+  set.seed(42)
+  dat <- rexp(30)
+  bs <- boot::boot(dat, function(d, i) mean(d[i]), R = 10000)
+
+  # Reference: Efron's a from the empirical influence values of the data
+  L <- boot::empinf(bs)
+  a_jackknife <- sum(L^3) / (6 * sum(L^2)^1.5)
+
+  # What .bci() computes from the replicates alone
+  draws <- as.numeric(bs$t)
+  deviation <- draws - mean(draws)
+  a_draws <- mean(deviation^3) / (6 * mean(deviation^2)^1.5)
+
+  expect_identical(sign(a_draws), sign(a_jackknife))
+  expect_equal(a_draws, a_jackknife, tolerance = 0.2)
+
+  # End to end: interval endpoints against boot.ci() on the same replicates
+  ci_boot <- boot::boot.ci(bs, conf = 0.95, type = "bca")$bca[4:5]
+  ci_bci <- bci(draws, ci = 0.95)
+  expect_equal(ci_bci$CI_low, ci_boot[1], tolerance = 0.02)
+  expect_equal(ci_bci$CI_high, ci_boot[2], tolerance = 0.02)
+})
+
+test_that("bci() endpoints follow the BCa formula with a = skewness / 6", {
+  set.seed(3)
+  x <- rgamma(4000, shape = 2)
+
+  m <- mean(x)
+  deviation <- x - m
+  a <- mean(deviation^3) / (6 * mean(deviation^2)^1.5)
+  z <- qnorm(sum(x < m) / length(x))
+  lower_p <- pnorm(z + (z + qnorm(0.025)) / (1 - a * (z + qnorm(0.025))))
+  upper_p <- pnorm(z + (z + qnorm(0.975)) / (1 - a * (z + qnorm(0.975))))
+  expected <- unname(quantile(x, c(lower_p, upper_p)))
+
+  out <- bci(x, ci = 0.95)
+  expect_equal(c(out$CI_low, out$CI_high), expected, tolerance = 1e-8)
+})
+
+test_that("bci() handles constant draws", {
+  out <- bci(rep(1, 100), verbose = FALSE)
+  expect_identical(c(out$CI_low, out$CI_high), c(1, 1))
+})


### PR DESCRIPTION
Fixes #572, following up on my diagnosis there.

The current `.bci()` applies the jackknife influence formula to the draws: `U <- (sims - 1) * (mean(x) - x)`. The `(sims - 1)` factors cancel, so this reduces to `a = -skew(x) / (6 * sqrt(sims))`. Compared with the definition in DiCiccio & Efron (1996, eq. 6.6) the sign is flipped, and the estimate shrinks toward zero as draws accumulate, so with typical MCMC sample sizes `bci()` has been returning a (slightly miscorrected) BC interval rather than a BCa interval.

As discussed in the issue, the influence values belong to the data points, which `bci()` never sees. What the draws do estimate directly is the distribution of the statistic itself, and one sixth of its standardized third moment targets the same quantity as eq. 6.6: for the mean of n observations, `skew(data) / (6 * sqrt(n)) = skew(draws) / 6` up to sampling error. So the PR replaces the influence-formula block with `a = skew(draws) / 6`, which has the right sign, does not depend on the number of draws, and needs no change to the API.

Against `boot` on shared replicates (mean of 30 exponential observations, R = 10000): `boot::empinf()` gives a = 0.0735, the draws give 0.0677, and the resulting interval endpoints agree with `boot.ci(type = "bca")` to well under one percent. The old code gave a = -0.0007 on the same replicates.

Also added: a degenerate-draws guard (constant draws previously produced `0 * Inf = NaN` endpoints; they now return the point interval), tests covering the agreement with `boot`, the exact endpoint formula, and the degenerate case, and a NEWS entry. `boot` is only used inside `skip_if_not_installed()`, so it does not need to be added to Suggests unless you prefer that.